### PR TITLE
FB Login

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,7 +41,13 @@ dependencies {
     compile 'com.parse:parse-android:1.13.1'
     compile 'com.parse:parseinterceptors:0.0.2' // for logging API calls to LogCat
     compile 'com.parse.bolts:bolts-android:1.+'
+    // Module dependency on ParseUI libraries sources
+    compile 'com.parse:parseui-login-android:0.0.1'
+    compile 'com.parse:parseui-widget-android:0.0.1'
 
+    // Uncomment if using Facebook Login (optional Maven dependency)
+    // compile 'com.facebook.android:facebook-android-sdk:4.6.0'
+    // compile 'com.parse:parsefacebookutils-v4-android:1.10.3@aar'
 
     // Google Places API
     compile 'com.google.android.gms:play-services-places:9.8.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,6 +22,7 @@ android {
 
 repositories {
     maven { url 'https://maven.fabric.io/public' }
+    mavenCentral()
 }
 
 dependencies {
@@ -44,10 +45,9 @@ dependencies {
     // Module dependency on ParseUI libraries sources
     compile 'com.parse:parseui-login-android:0.0.1'
     compile 'com.parse:parseui-widget-android:0.0.1'
-
-    // Uncomment if using Facebook Login (optional Maven dependency)
-    // compile 'com.facebook.android:facebook-android-sdk:4.6.0'
-    // compile 'com.parse:parsefacebookutils-v4-android:1.10.3@aar'
+    // Facebook Login (optional Maven dependency)
+     compile 'com.facebook.android:facebook-android-sdk:4.6.0'
+     compile 'com.parse:parsefacebookutils-v4-android:1.10.3@aar'
 
     // Google Places API
     compile 'com.google.android.gms:play-services-places:9.8.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,21 @@
             <meta-data
                 android:name="com.parse.ui.ParseLoginActivity.PARSE_LOGIN_EMAIL_AS_USERNAME"
                 android:value="false"/>
+            <meta-data
+                android:name="com.parse.ui.ParseLoginActivity.FACEBOOK_LOGIN_ENABLED"
+                android:value="true"/>
         </activity>
+        <activity android:name="com.facebook.FacebookActivity"
+            android:configChanges=
+                "keyboard|keyboardHidden|screenLayout|screenSize|orientation"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:label="@string/app_name" />
+            <meta-data
+                android:name="com.facebook.sdk.ApplicationId"
+                android:value="@string/facebook_app_id" />
+            <meta-data
+                android:name="com.facebook.sdk.PERMISSIONS"
+                android:value="email" />
         <activity android:name=".HomeActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,18 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+        <activity
+            android:name="com.parse.ui.ParseLoginActivity"
+            android:label="@string/app_name"
+            android:launchMode="singleTop">
+            <!-- For more options, see https://www.parse.com/docs/android_guide#ui-login -->
+            <meta-data
+                android:name="com.parse.ui.ParseLoginActivity.PARSE_LOGIN_ENABLED"
+                android:value="true"/>
+            <meta-data
+                android:name="com.parse.ui.ParseLoginActivity.PARSE_LOGIN_EMAIL_AS_USERNAME"
+                android:value="false"/>
+        </activity>
         <activity android:name=".HomeActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,9 +21,6 @@
                 android:name="com.parse.ui.ParseLoginActivity.PARSE_LOGIN_ENABLED"
                 android:value="true"/>
             <meta-data
-                android:name="com.parse.ui.ParseLoginActivity.PARSE_LOGIN_EMAIL_AS_USERNAME"
-                android:value="false"/>
-            <meta-data
                 android:name="com.parse.ui.ParseLoginActivity.FACEBOOK_LOGIN_ENABLED"
                 android:value="true"/>
         </activity>

--- a/app/src/main/java/com/codepath/travel/HomeActivity.java
+++ b/app/src/main/java/com/codepath/travel/HomeActivity.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.codepath.travel.models.User;
 import com.crashlytics.android.Crashlytics;
 import com.parse.ParseUser;
 import com.parse.ui.ParseLoginBuilder;
@@ -38,7 +39,7 @@ public class HomeActivity extends AppCompatActivity {
 
     // Get the userId from the cached currentUser object
     private void startWithCurrentUser() {
-        ParseUser user = ParseUser.getCurrentUser();
+        User user = (User) ParseUser.getCurrentUser();
         Toast.makeText(HomeActivity.this, "Using user: " + user.getUsername(), Toast.LENGTH_SHORT).show();
         this.tvHello.setText(String.format("Hello, %s!", ParseUser.getCurrentUser().getUsername()));
     }
@@ -52,7 +53,7 @@ public class HomeActivity extends AppCompatActivity {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (resultCode == RESULT_OK && requestCode == LOGIN_REQUEST_CODE) {
-            ParseUser user = ParseUser.getCurrentUser();
+            User user = (User) ParseUser.getCurrentUser();
             Toast.makeText(this, String.format("Logged in: %s", user.getUsername()), Toast.LENGTH_SHORT).show();
             this.tvHello.setText(String.format("Hello, %s!", user.getUsername()));
         }

--- a/app/src/main/java/com/codepath/travel/HomeActivity.java
+++ b/app/src/main/java/com/codepath/travel/HomeActivity.java
@@ -3,6 +3,8 @@ package com.codepath.travel;
 import android.content.Intent;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -10,6 +12,9 @@ import com.codepath.travel.models.User;
 import com.crashlytics.android.Crashlytics;
 import com.parse.ParseUser;
 import com.parse.ui.ParseLoginBuilder;
+import com.facebook.FacebookSdk;
+import com.facebook.appevents.AppEventsLogger;
+import com.parse.ParseFacebookUtils;
 
 import io.fabric.sdk.android.Fabric;
 
@@ -24,7 +29,11 @@ public class HomeActivity extends AppCompatActivity {
         setContentView(R.layout.activity_home);
 
         // fabric crash reporting
-        Fabric.with(this, new Crashlytics());
+//        Fabric.with(this, new Crashlytics());
+
+        // facebook integration
+        FacebookSdk.sdkInitialize(getApplicationContext());
+        AppEventsLogger.activateApp(getApplication());
 
         this.tvHello = (TextView) findViewById(R.id.hello);
 
@@ -44,18 +53,25 @@ public class HomeActivity extends AppCompatActivity {
         this.tvHello.setText(String.format("Hello, %s!", ParseUser.getCurrentUser().getUsername()));
     }
 
-    private static final int LOGIN_REQUEST_CODE = 0;
+    private static final int LOGIN_REQUEST = 0;
     private void launchLoginActivity() {
         ParseLoginBuilder builder = new ParseLoginBuilder(HomeActivity.this);
-        startActivityForResult(builder.build(), LOGIN_REQUEST_CODE);
+        startActivityForResult(builder.build(), LOGIN_REQUEST);
     }
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (resultCode == RESULT_OK && requestCode == LOGIN_REQUEST_CODE) {
+        if (resultCode == RESULT_OK && requestCode == LOGIN_REQUEST) {
+            ParseFacebookUtils.onActivityResult(requestCode, resultCode, data);
             User user = (User) ParseUser.getCurrentUser();
             Toast.makeText(this, String.format("Logged in: %s", user.getUsername()), Toast.LENGTH_SHORT).show();
             this.tvHello.setText(String.format("Hello, %s!", user.getUsername()));
         }
+    }
+
+    public void onLogout(View view) {
+        ParseUser.logOut();
+        Log.d(TAG, "Logged out");
+        launchLoginActivity();
     }
 }

--- a/app/src/main/java/com/codepath/travel/HomeActivity.java
+++ b/app/src/main/java/com/codepath/travel/HomeActivity.java
@@ -1,12 +1,21 @@
 package com.codepath.travel;
 
+import android.content.Intent;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.widget.TextView;
+import android.widget.Toast;
 
 import com.crashlytics.android.Crashlytics;
+import com.parse.ParseUser;
+import com.parse.ui.ParseLoginBuilder;
+
 import io.fabric.sdk.android.Fabric;
 
 public class HomeActivity extends AppCompatActivity {
+    static final String TAG = HomeActivity.class.getSimpleName();
+
+    private TextView tvHello;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -15,6 +24,37 @@ public class HomeActivity extends AppCompatActivity {
 
         // fabric crash reporting
         Fabric.with(this, new Crashlytics());
+
+        this.tvHello = (TextView) findViewById(R.id.hello);
+
+        // User login
+        if (ParseUser.getCurrentUser() != null) { // start with existing user
+            startWithCurrentUser();
+        } else {
+            launchLoginActivity();
+        }
+
     }
 
+    // Get the userId from the cached currentUser object
+    private void startWithCurrentUser() {
+        ParseUser user = ParseUser.getCurrentUser();
+        Toast.makeText(HomeActivity.this, "Using user: " + user.getUsername(), Toast.LENGTH_SHORT).show();
+        this.tvHello.setText(String.format("Hello, %s!", ParseUser.getCurrentUser().getUsername()));
+    }
+
+    private static final int LOGIN_REQUEST_CODE = 0;
+    private void launchLoginActivity() {
+        ParseLoginBuilder builder = new ParseLoginBuilder(HomeActivity.this);
+        startActivityForResult(builder.build(), LOGIN_REQUEST_CODE);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (resultCode == RESULT_OK && requestCode == LOGIN_REQUEST_CODE) {
+            ParseUser user = ParseUser.getCurrentUser();
+            Toast.makeText(this, String.format("Logged in: %s", user.getUsername()), Toast.LENGTH_SHORT).show();
+            this.tvHello.setText(String.format("Hello, %s!", user.getUsername()));
+        }
+    }
 }

--- a/app/src/main/java/com/codepath/travel/ParseApplication.java
+++ b/app/src/main/java/com/codepath/travel/ParseApplication.java
@@ -9,6 +9,7 @@ import com.codepath.travel.models.Tag;
 import com.codepath.travel.models.Trip;
 import com.codepath.travel.models.User;
 import com.parse.Parse;
+import com.parse.ParseFacebookUtils;
 import com.parse.ParseObject;
 import com.parse.ParseUser;
 import com.parse.interceptors.ParseLogInterceptor;
@@ -43,9 +44,7 @@ public class ParseApplication extends Application {
                 .addNetworkInterceptor(new ParseLogInterceptor())
                 .server(SERVER_URL).build());
 
-        // New test creation of object below
-        ParseObject testObject = new ParseObject("TestObject");
-        testObject.put("foo", "bar");
-        testObject.saveInBackground();
+        // ParseFacebookUtils should initialize the Facebook SDK for you
+        ParseFacebookUtils.initialize(this);
     }
 }

--- a/app/src/main/java/com/codepath/travel/models/ParseModelConstants.java
+++ b/app/src/main/java/com/codepath/travel/models/ParseModelConstants.java
@@ -6,7 +6,7 @@ package com.codepath.travel.models;
 public final class ParseModelConstants {
 
     // User-specific values
-    public static final String USER_CLASS_NAME = "User";
+    public static final String USER_CLASS_NAME = "_User";
     public static final String FB_UID_KEY = "fbUid";
     public static final String PROFILE_PIC_URL_KEY = "profilePicUrl";
     public static final String FOLLOWING_RELATION_KEY = "following";

--- a/app/src/main/java/com/codepath/travel/models/User.java
+++ b/app/src/main/java/com/codepath/travel/models/User.java
@@ -20,18 +20,8 @@ import static com.codepath.travel.models.ParseModelConstants.USER_KEY;
 @ParseClassName(USER_CLASS_NAME)
 public class User extends ParseUser {
 
-    private ParseUser user;
-
     public User() {
         super();
-    }
-
-    public User(String username, String email, String password) {
-        super();
-        user = new ParseUser();
-        user.setUsername(username);
-        user.setEmail(email);
-        user.setPassword(password);
     }
 
     public int getFbUid() {
@@ -60,7 +50,7 @@ public class User extends ParseUser {
 
     public void queryTrips(FindCallback<Trip> callback) {
         ParseQuery<Trip> query = ParseQuery.getQuery(Trip.class);
-        query.whereEqualTo(USER_KEY, user);
+        query.whereEqualTo(USER_KEY, this);
         query.findInBackground(callback);
     }
 
@@ -102,7 +92,7 @@ public class User extends ParseUser {
 
     public void queryFollowers(FindCallback<User> callback) {
         ParseQuery<User> query = ParseQuery.getQuery(USER_CLASS_NAME);
-        query.whereEqualTo(FOLLOWING_RELATION_KEY, user);
+        query.whereEqualTo(FOLLOWING_RELATION_KEY, this);
         query.findInBackground(callback);
     }
 

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -11,6 +11,7 @@
     android:paddingTop="@dimen/activity_vertical_margin"
     tools:context="com.codepath.travel.HomeActivity">
 
+    <!-- Debugging Views: feel free to change or delete -->
     <TextView
         android:id="@+id/hello"
         android:layout_width="wrap_content"
@@ -24,5 +25,13 @@
         android:layout_below="@+id/hello"
         android:text="@string/logout"
         android:onClick="onLogout"/>
+
+    <Button
+        android:id="@+id/btnDeleteAccount"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/btnLogout"
+        android:text="@string/deleteAccount"
+        android:onClick="onDeleteAccount"/>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -17,4 +17,12 @@
         android:layout_height="wrap_content"
         android:text="Hello World!"/>
 
+    <Button
+        android:id="@+id/btnLogout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/hello"
+        android:text="@string/logout"
+        android:onClick="onLogout"/>
+
 </RelativeLayout>

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -12,6 +12,7 @@
     tools:context="com.codepath.travel.HomeActivity">
 
     <TextView
+        android:id="@+id/hello"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Hello World!"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,5 +6,7 @@
 
     <string name="app_name">Travel</string>
 
+    <!-- Account Management -->
     <string name="logout">Logout</string>
+    <string name="deleteAccount">Delete Account</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,5 +2,9 @@
     <!-- APIs and Integrations -->
     <string name="parse_app_id">traveltrails</string>
     <string name="google_api_key">AIzaSyD4JhCWAAVr5oxzC9dzYQl6ed2OeHXuLdQ</string>
+    <string name="facebook_app_id">646488778862200</string>
+
     <string name="app_name">Travel</string>
+
+    <string name="logout">Logout</string>
 </resources>


### PR DESCRIPTION
Issue: https://github.com/codepath-android-fall16-group-8/travel/issues/4

I used the Parse UI and FacebookUtils libraries mentioned in the guide here (under FB SDK): https://guides.codepath.com/android/Building-Data-driven-Apps-with-Parse#additional-features

For now you can create your own Parse account for testing or whatever OR login with FB. Later if we want, we can remove the Parse login.

In order for FB to work, you need to send me your debug key hash so I can add it to our FB app settings.
```
cd ~/.android
keytool -exportcert -alias androiddebugkey -keystore ~/.android/debug.keystore | openssl sha1 -binary | openssl base64
# when prompted, password is "android"
```

If you install the FB app on your emulator and then login through the app, it should be pretty seamless! Otherwise you have to type in your FB username and password every time which is annoying.