### PR TITLE
model rework exploration + trip creation bugfixes

### DIFF
--- a/app/src/main/java/com/codepath/travel/activities/CreateStoryActivity.java
+++ b/app/src/main/java/com/codepath/travel/activities/CreateStoryActivity.java
@@ -26,6 +26,7 @@ import com.google.android.gms.common.GooglePlayServicesRepairableException;
 import com.google.android.gms.common.api.Status;
 import com.google.android.gms.location.places.Place;
 import com.google.android.gms.location.places.ui.PlaceAutocomplete;
+import com.parse.ParseACL;
 import com.parse.ParseException;
 import com.parse.ParseUser;
 
@@ -79,7 +80,11 @@ public class CreateStoryActivity extends AppCompatActivity implements OnStartDra
     }
 
     private void setUpTrip() {
-        mNewTrip = new Trip(ParseUser.getCurrentUser(), mDestination);
+        ParseUser currentUser = ParseUser.getCurrentUser();
+        currentUser.setACL(new ParseACL(currentUser));
+        currentUser.saveInBackground();
+        mNewTrip = new Trip(currentUser, mDestination);
+        mNewTrip.saveInBackground();
     }
 
     private void setUpClickListeners() {
@@ -102,7 +107,7 @@ public class CreateStoryActivity extends AppCompatActivity implements OnStartDra
                     setResult(RESULT_OK);
                     finish();
                 } else {
-                    Toast.makeText(CreateStoryActivity.this, "Error saving", Toast.LENGTH_SHORT).show();
+                    Log.d("createStory", String.format("Failed: %s", e.getMessage()));
                 }
             });
         });

--- a/app/src/main/java/com/codepath/travel/activities/HomeActivity.java
+++ b/app/src/main/java/com/codepath/travel/activities/HomeActivity.java
@@ -1,6 +1,5 @@
 package com.codepath.travel.activities;
 
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
@@ -15,7 +14,6 @@ import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.ImageView;
 import android.widget.ListView;
@@ -97,7 +95,6 @@ public class HomeActivity extends AppCompatActivity
             launchLoginActivity();
         }
         setUpClickListeners();
-        refreshMyTrips();
     }
 
     private void setupViews() {
@@ -118,7 +115,6 @@ public class HomeActivity extends AppCompatActivity
         mTrips = new ArrayList<>();
         mTripsAdapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, mTrips);
         lvMyTrips.setAdapter(mTripsAdapter);
-        refreshMyTrips();
 
         mFab = (FloatingActionButton) findViewById(R.id.fab_new_trip);
     }
@@ -139,23 +135,18 @@ public class HomeActivity extends AppCompatActivity
     }
 
     private void setUpClickListeners() {
-        lvMyTrips.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-            @Override
-            public void onItemClick(AdapterView<?> adapterView, View view, int position, long l) {
-                Trip trip = mTripsAdapter.getItem(position);
-                Intent openStory = new Intent(HomeActivity.this, StoryActivity.class);
-                openStory.putExtra(StoryActivity.TRIP_ID_ARG, trip.getObjectId());
-                startActivity(openStory);
-            }
+        lvMyTrips.setOnItemClickListener((adapterView, view, position, l) -> {
+            Trip trip = mTripsAdapter.getItem(position);
+            Intent openStory = new Intent(HomeActivity.this, StoryActivity.class);
+            openStory.putExtra(StoryActivity.TRIP_TITLE_ARG, trip.getTitle());
+            openStory.putExtra(StoryActivity.TRIP_ID_ARG, trip.getObjectId());
+            startActivity(openStory);
         });
 
-        mFab.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                FragmentManager fm = getSupportFragmentManager();
-                NewTripFragment newTripDialog = NewTripFragment.newInstance();
-                newTripDialog.show(fm, "New Trip");
-            }
+        mFab.setOnClickListener(view -> {
+            FragmentManager fm = getSupportFragmentManager();
+            NewTripFragment newTripDialog = NewTripFragment.newInstance();
+            newTripDialog.show(fm, "New Trip");
         });
     }
 
@@ -168,6 +159,7 @@ public class HomeActivity extends AppCompatActivity
                 .fitCenter()
                 .bitmapTransform(new CropCircleTransformation(this))
                 .into(this.ivProfileImage);
+        refreshMyTrips();
     }
 
     private void newFBAccountSetup(final User user) {

--- a/app/src/main/java/com/codepath/travel/models/ParseModelConstants.java
+++ b/app/src/main/java/com/codepath/travel/models/ParseModelConstants.java
@@ -5,8 +5,6 @@ package com.codepath.travel.models;
  */
 public final class ParseModelConstants {
 
-    public static final String OBJECT_ID_KEY = "objectId";
-
     // User-specific values
     public static final String USER_CLASS_NAME = "_User";
     public static final String FB_UID_KEY = "fbUid";

--- a/app/src/main/java/com/codepath/travel/models/StoryPlace.java
+++ b/app/src/main/java/com/codepath/travel/models/StoryPlace.java
@@ -20,17 +20,14 @@ import static com.codepath.travel.models.ParseModelConstants.RATING_KEY;
 import static com.codepath.travel.models.ParseModelConstants.STORY_PLACE_CLASS_NAME;
 import static com.codepath.travel.models.ParseModelConstants.TRIP_KEY;
 
-import org.parceler.Parcel;
-
 /**
  * Parse model for a travel story/trip.
  */
 @ParseClassName(STORY_PLACE_CLASS_NAME)
-@Parcel(analyze={StoryPlace.class})
 public class StoryPlace extends ParseObject {
 
     public StoryPlace() {
-        // empty constructor for parceler
+        super();
     }
 
     // for testing, DELETE ME after we have API places

--- a/app/src/main/java/com/codepath/travel/models/Trip.java
+++ b/app/src/main/java/com/codepath/travel/models/Trip.java
@@ -3,7 +3,6 @@ package com.codepath.travel.models;
 import com.google.android.gms.location.places.Place;
 import com.parse.FindCallback;
 import com.parse.ParseClassName;
-import com.parse.ParseException;
 import com.parse.ParseObject;
 import com.parse.ParseQuery;
 import com.parse.ParseRelation;
@@ -11,29 +10,20 @@ import com.parse.ParseUser;
 
 import static com.codepath.travel.models.ParseModelConstants.COVER_PIC_URL_KEY;
 import static com.codepath.travel.models.ParseModelConstants.DESTINATION_PLACE_ID_KEY;
-import static com.codepath.travel.models.ParseModelConstants.OBJECT_ID_KEY;
 import static com.codepath.travel.models.ParseModelConstants.SHARED_RELATION_KEY;
 import static com.codepath.travel.models.ParseModelConstants.STORY_PLACE_CLASS_NAME;
 import static com.codepath.travel.models.ParseModelConstants.TITLE_KEY;
 import static com.codepath.travel.models.ParseModelConstants.TRIP_CLASS_NAME;
 import static com.codepath.travel.models.ParseModelConstants.USER_KEY;
 
-import android.util.Log;
-
-import org.parceler.Parcel;
-
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * Parse model for a travel story/trip.
  */
 @ParseClassName(TRIP_CLASS_NAME)
-@Parcel(analyze={Trip.class})
 public class Trip extends ParseObject {
 
     public Trip() {
-        // empty constructor for parceler
+        super();
     }
 
     // for use until we use API places
@@ -107,16 +97,9 @@ public class Trip extends ParseObject {
     // TODO: figure out how to query for all tags inside this trip (including storyPlace and media tags)
 
     public static void getPlaces(String tripId, FindCallback callback) {
-        ParseQuery<Trip> tripQuery = ParseQuery.getQuery(TRIP_CLASS_NAME);
-        tripQuery.whereEqualTo(OBJECT_ID_KEY, tripId);
-        tripQuery.findInBackground((List<Trip> trips, ParseException e) -> {
-            if (e == null) {
-                ParseQuery<StoryPlace> storyQuery = ParseQuery.getQuery(STORY_PLACE_CLASS_NAME);
-                storyQuery.whereEqualTo(ParseModelConstants.TRIP_KEY, trips.get(0));
-                storyQuery.findInBackground(callback);
-            } else {
-                Log.d("trip query error", e.toString());
-            }
-        });
+        ParseQuery<StoryPlace> storyQuery = ParseQuery.getQuery(STORY_PLACE_CLASS_NAME);
+        storyQuery.whereEqualTo(ParseModelConstants.TRIP_KEY,
+                ParseObject.createWithoutData(Trip.class, tripId));
+        storyQuery.findInBackground(callback);
     }
 }


### PR DESCRIPTION
* HomeActivity - refreshMyTrips is only called once the logged in user is determined, and after trip creation
* ACL issues when creating a new trip after reopening the app (see https://github.com/ParsePlatform/Parse-SDK-Android/issues/499): used the hacky solution of setting the ACL keys.
* Fetching story places with a given trip id: we don't need to fetch the trip, we can just pass the trip id like so using `ParseObject.createWithoutData`:
```
    public static void getPlaces(String tripId, FindCallback callback) {
        ParseQuery<StoryPlace> storyQuery = ParseQuery.getQuery(STORY_PLACE_CLASS_NAME);
        storyQuery.whereEqualTo(ParseModelConstants.TRIP_KEY,
                ParseObject.createWithoutData(Trip.class, tripId));
        storyQuery.findInBackground(callback);
    }
```