### PR TITLE
do not extend ParseUser

### DIFF
--- a/app/src/main/java/com/codepath/travel/ParseApplication.java
+++ b/app/src/main/java/com/codepath/travel/ParseApplication.java
@@ -28,7 +28,6 @@ public class ParseApplication extends Application {
         super.onCreate();
 
         // Register parse models
-        ParseUser.registerSubclass(User.class);
         ParseObject.registerSubclass(Trip.class);
         ParseObject.registerSubclass(StoryPlace.class);
         ParseObject.registerSubclass(SavedPlace.class);

--- a/app/src/main/java/com/codepath/travel/activities/HomeActivity.java
+++ b/app/src/main/java/com/codepath/travel/activities/HomeActivity.java
@@ -1,5 +1,10 @@
 package com.codepath.travel.activities;
 
+import static com.codepath.travel.models.User.getCoverPicUrl;
+import static com.codepath.travel.models.User.getProfilePicUrl;
+import static com.codepath.travel.models.User.setCoverPicUrl;
+import static com.codepath.travel.models.User.setFbUid;
+import static com.codepath.travel.models.User.setProfilePicUrl;
 import static com.parse.ParseUser.getCurrentUser;
 
 import android.content.Intent;
@@ -16,7 +21,6 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.MenuItem;
-import android.view.View;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
@@ -28,7 +32,6 @@ import com.codepath.travel.fragments.PlannedTripListFragment;
 import com.codepath.travel.fragments.TripClickListener;
 import com.codepath.travel.fragments.TripItemFragment;
 import com.codepath.travel.helper.ImageUtils;
-import com.codepath.travel.models.User;
 import com.facebook.AccessToken;
 import com.facebook.FacebookSdk;
 import com.facebook.GraphRequest;
@@ -56,14 +59,13 @@ public class HomeActivity extends AppCompatActivity implements TripClickListener
     @BindView(R.id.nvView) NavigationView nvDrawer;
     @BindView(R.id.fab_new_trip) FloatingActionButton mFab;
 
-    private ActionBarDrawerToggle drawerToggle;
-
     // Fragments
     private PastTripListFragment pastTripsFragment;
     private PlannedTripListFragment plannedTripsFragment;
     private TripItemFragment currentTripFragment;
 
     // Views in Navigation view
+    private ActionBarDrawerToggle drawerToggle;
     private ImageView ivProfileImage;
     private TextView tvProfileName;
     private RelativeLayout nvHeader;
@@ -85,14 +87,6 @@ public class HomeActivity extends AppCompatActivity implements TripClickListener
         setupDrawerContent(nvDrawer);
         setUpClickListeners();
 
-        // User login
-        if (getCurrentUser() != null) { // start with existing user
-            startWithCurrentUser();
-
-        } else {
-            launchLoginActivity();
-        }
-
         if (savedInstanceState == null) {
             setupTripFragments();
         } else {
@@ -100,6 +94,14 @@ public class HomeActivity extends AppCompatActivity implements TripClickListener
             plannedTripsFragment = (PlannedTripListFragment) fm.findFragmentByTag("plannedTripsFragment");
             currentTripFragment = (TripItemFragment) fm.findFragmentByTag("currentTripFragment");
             pastTripsFragment = (PastTripListFragment) fm.findFragmentByTag("pastTripsFragment");
+        }
+
+        // User login
+        if (getCurrentUser() != null) { // start with existing user
+            startWithCurrentUser();
+
+        } else {
+            launchLoginActivity();
         }
     }
 
@@ -150,32 +152,32 @@ public class HomeActivity extends AppCompatActivity implements TripClickListener
 
     // Get the userId from the cached currentUser object
     private void startWithCurrentUser() {
-        User user = (User) getCurrentUser();
-        this.tvProfileName.setText(user.getUsername());
-        ImageUtils.loadImageCircle(this.ivProfileImage, user.getProfilePicUrl(),
+        ParseUser pUser = getCurrentUser();
+        this.tvProfileName.setText(pUser.getUsername());
+        ImageUtils.loadImageCircle(this.ivProfileImage, getProfilePicUrl(pUser),
                 R.drawable.com_facebook_profile_picture_blank_portrait);
-        ImageUtils.loadBackground(nvHeader, user.getCoverPicUrl());
+        ImageUtils.loadBackground(nvHeader, getCoverPicUrl(pUser));
     }
 
-    private void newFBAccountSetup(final User user) {
+    private void newFBAccountSetup(ParseUser pUser) {
         Log.d(TAG, String.format("New FB Account setup for: %s",
-                user.getUsername()));
+                pUser.getUsername()));
         GraphRequest request = GraphRequest.newMeRequest(
                 AccessToken.getCurrentAccessToken(),
                 (object, response) -> {
                     try {
-                        user.setFbUid(object.getInt("id"));
-                        user.setUsername(object.getString("name"));
+                        setFbUid(pUser, object.getInt("id"));
+                        pUser.setUsername(object.getString("name"));
                         if (object.has("email")) {
-                            user.setEmail(object.getString("email"));
+                            pUser.setEmail(object.getString("email"));
                         }
                         if (object.has("picture")) {
-                            user.setProfilePicUrl(object.getJSONObject("picture").getJSONObject("data").getString("url"));
+                            setProfilePicUrl(pUser, object.getJSONObject("picture").getJSONObject("data").getString("url"));
                         }
                         if (object.has("cover")) {
-                            user.setCoverPicUrl(object.getJSONObject("cover").getString("source"));
+                            setCoverPicUrl(pUser, object.getJSONObject("cover").getString("source"));
                         }
-                        user.saveInBackground(e -> {
+                        pUser.saveInBackground(e -> {
                             if (e == null) {
                                 startWithCurrentUser();
                             }
@@ -229,12 +231,12 @@ public class HomeActivity extends AppCompatActivity implements TripClickListener
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (resultCode == RESULT_OK && requestCode == LOGIN_REQUEST) {
             ParseFacebookUtils.onActivityResult(requestCode, resultCode, data);
-            User user = (User) getCurrentUser();
+            ParseUser pUser = getCurrentUser();
             // update user fields if this is a new facebook login
-            if (user.isNew() && ParseFacebookUtils.isLinked(user)) {
-                newFBAccountSetup(user);
+            if (pUser.isNew() && ParseFacebookUtils.isLinked(pUser)) {
+                newFBAccountSetup(pUser);
             } else {
-                setTripFragmentsUser(user.getObjectId());
+                setTripFragmentsUser(pUser.getObjectId());
                 startWithCurrentUser();
             }
         } else if (resultCode == RESULT_OK && requestCode == CREATE_STORY_REQUEST) {

--- a/app/src/main/java/com/codepath/travel/activities/StoryActivity.java
+++ b/app/src/main/java/com/codepath/travel/activities/StoryActivity.java
@@ -1,5 +1,7 @@
 package com.codepath.travel.activities;
 
+import static com.codepath.travel.models.User.setCoverPicUrl;
+
 import android.Manifest;
 import android.app.FragmentTransaction;
 import android.content.Intent;
@@ -29,7 +31,6 @@ import com.codepath.travel.helper.SimpleItemTouchHelperCallback;
 import com.codepath.travel.models.Media;
 import com.codepath.travel.models.StoryPlace;
 import com.codepath.travel.models.Trip;
-import com.codepath.travel.models.User;
 import com.parse.FindCallback;
 import com.parse.ParseException;
 import com.parse.ParseFile;
@@ -364,8 +365,8 @@ public class StoryActivity extends AppCompatActivity implements OnStartDragListe
 
     @Override
     public void onSetUserCoverPhoto(String coverUrl) {
-        User user = (User) ParseUser.getCurrentUser();
-        user.setCoverPicUrl(coverUrl);
+        ParseUser user = ParseUser.getCurrentUser();
+        setCoverPicUrl(user, coverUrl);
         user.saveInBackground();
     }
 

--- a/app/src/main/java/com/codepath/travel/adapters/TripsAdapter.java
+++ b/app/src/main/java/com/codepath/travel/adapters/TripsAdapter.java
@@ -1,5 +1,7 @@
 package com.codepath.travel.adapters;
 
+import static com.codepath.travel.models.User.getProfilePicUrl;
+
 import android.content.Context;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -58,7 +60,7 @@ public class TripsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         ImageUtils.loadBackground(rlBackground, trip.getCoverPicUrl());
         ImageView ivProfilePhoto = viewHolder.getProfilePhoto();
         if (showProfilePhoto) {
-            ImageUtils.loadImageCircle(ivProfilePhoto, ((User) trip.getUser()).getProfilePicUrl(),
+            ImageUtils.loadImageCircle(ivProfilePhoto, getProfilePicUrl(trip.getUser()),
                     R.drawable.com_facebook_profile_picture_blank_portrait);
         } else {
             ivProfilePhoto.setVisibility(View.GONE);

--- a/app/src/main/java/com/codepath/travel/fragments/TripItemFragment.java
+++ b/app/src/main/java/com/codepath/travel/fragments/TripItemFragment.java
@@ -2,6 +2,7 @@ package com.codepath.travel.fragments;
 
 import static com.codepath.travel.fragments.TripListFragment.FETCH_USER_ARG;
 import static com.codepath.travel.fragments.TripListFragment.USER_ID_ARG;
+import static com.codepath.travel.models.User.getProfilePicUrl;
 
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -18,7 +19,6 @@ import com.codepath.travel.R;
 import com.codepath.travel.helper.DateUtils;
 import com.codepath.travel.helper.ImageUtils;
 import com.codepath.travel.models.Trip;
-import com.codepath.travel.models.User;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -81,13 +81,15 @@ public class TripItemFragment extends Fragment {
 
     public void populateTrip() {
         if (mUserId == null) {
+            rlBackground.setVisibility(View.INVISIBLE);
             return;
         }
+        rlBackground.setVisibility(View.VISIBLE);
         Trip.getCurrentTripForUser(mUserId, fetchUser, (trip, e) -> {
             if (e == null) {
                 mTrip = trip;
                 if (fetchUser) {
-                    ImageUtils.loadImageCircle(ivProfilePhoto, ((User) trip.getUser()).getProfilePicUrl(),
+                    ImageUtils.loadImageCircle(ivProfilePhoto, getProfilePicUrl(trip.getUser()),
                             R.drawable.com_facebook_profile_picture_blank_portrait);
                 } else {
                     ivProfilePhoto.setVisibility(View.GONE);
@@ -98,6 +100,7 @@ public class TripItemFragment extends Fragment {
                         trip.getStartDate(), trip.getEndDate()));
             } else {
                 Log.d(TAG, String.format("Failed to find current trip for user %s: %s", mUserId, e.getMessage()));
+                rlBackground.setVisibility(View.INVISIBLE);
             }
         });
     }

--- a/app/src/main/java/com/codepath/travel/models/ParseModelConstants.java
+++ b/app/src/main/java/com/codepath/travel/models/ParseModelConstants.java
@@ -8,7 +8,6 @@ public final class ParseModelConstants {
     public static final String OBJECT_ID_KEY = "objectId";
 
     // User-specific values
-    public static final String USER_CLASS_NAME = "_User";
     public static final String FB_UID_KEY = "fbUid";
     public static final String PROFILE_PIC_URL_KEY = "profilePicUrl";
     public static final String FOLLOWING_RELATION_KEY = "following";

--- a/app/src/main/java/com/codepath/travel/models/Tag.java
+++ b/app/src/main/java/com/codepath/travel/models/Tag.java
@@ -20,19 +20,19 @@ public class Tag extends ParseObject {
         super();
     }
 
-    public Tag(User user, Trip trip) {
+    public Tag(ParseUser user, Trip trip) {
         super();
         setUser(user);
         setTrip(trip);
     }
 
-    public Tag(User user, StoryPlace storyPlace) {
+    public Tag(ParseUser user, StoryPlace storyPlace) {
         super();
         setUser(user);
         setStoryPlace(storyPlace);
     }
 
-    public Tag(User user, Media media) {
+    public Tag(ParseUser user, Media media) {
         super();
         setUser(user);
         setMedia(media);

--- a/app/src/main/java/com/codepath/travel/models/Trip.java
+++ b/app/src/main/java/com/codepath/travel/models/Trip.java
@@ -14,8 +14,6 @@ import static com.codepath.travel.models.ParseModelConstants.*;
 import android.text.TextUtils;
 import android.util.Log;
 
-import org.w3c.dom.Text;
-
 import java.util.ArrayList;
 import java.util.Date;
 
@@ -96,23 +94,23 @@ public class Trip extends ParseObject {
         put(END_DATE_KEY, endDate);
     }
 
-    public ParseRelation<User> getSharedRelation() {
+    public ParseRelation<ParseUser> getSharedRelation() {
         return getRelation(SHARED_RELATION_KEY);
     }
 
-    public void shareWith(User user) {
-        getSharedRelation().add(user);
+    public void shareWith(ParseUser pUser) {
+        getSharedRelation().add(pUser);
         saveInBackground();
     }
 
-    public void unShareWith(User user) {
-        getSharedRelation().remove(user);
+    public void unShareWith(ParseUser pUser) {
+        getSharedRelation().remove(pUser);
         saveInBackground();
     }
 
-    public void queryFavorites(FindCallback<User> callback) {
-        getSharedRelation().getQuery().findInBackground(callback);
-    }
+//    public void queryFavorites(FindCallback<ParseUser> callback) {
+//        getSharedRelation().getQuery().findInBackground(callback);
+//    }
 
     public String toString() {
         return getTitle();

--- a/app/src/main/java/com/codepath/travel/models/User.java
+++ b/app/src/main/java/com/codepath/travel/models/User.java
@@ -1,7 +1,6 @@
 package com.codepath.travel.models;
 
 import com.parse.FindCallback;
-import com.parse.ParseClassName;
 import com.parse.ParseQuery;
 import com.parse.ParseRelation;
 import com.parse.ParseUser;
@@ -11,94 +10,86 @@ import static com.codepath.travel.models.ParseModelConstants.FB_UID_KEY;
 import static com.codepath.travel.models.ParseModelConstants.FOLLOWING_RELATION_KEY;
 import static com.codepath.travel.models.ParseModelConstants.PHOTO_URL;
 import static com.codepath.travel.models.ParseModelConstants.PROFILE_PIC_URL_KEY;
-import static com.codepath.travel.models.ParseModelConstants.USER_CLASS_NAME;
 import static com.codepath.travel.models.ParseModelConstants.USER_KEY;
 
 import android.text.TextUtils;
 
 /**
- * Parse user model.
+ * ParseUser helper methods for extended fields and relations.
  */
-@ParseClassName(USER_CLASS_NAME)
-public class User extends ParseUser {
+public final class User {
 
-    public User() {
-        super();
+    private User() {}
+
+    public static int getFbUid(ParseUser pUser) {
+        return pUser.getInt(FB_UID_KEY);
     }
 
-    public int getFbUid() {
-        return getInt(FB_UID_KEY);
+    public static void setFbUid(ParseUser pUser, int fbUid) {
+        pUser.put(FB_UID_KEY, fbUid);
     }
 
-    public void setFbUid(int fbUid) {
-        put(FB_UID_KEY, fbUid);
+    public static String getProfilePicUrl(ParseUser pUser) {
+        return pUser.getString(PROFILE_PIC_URL_KEY);
     }
 
-    public String getProfilePicUrl() {
-        return getString(PROFILE_PIC_URL_KEY);
+    public static void setProfilePicUrl(ParseUser pUser, String profilePicUrl) {
+        pUser.put(PROFILE_PIC_URL_KEY, profilePicUrl);
     }
 
-    public void setProfilePicUrl(String profilePicUrl) {
-        put(PROFILE_PIC_URL_KEY, profilePicUrl);
-    }
-
-    public String getCoverPicUrl() {
-        String coverUrl = getString(PHOTO_URL);
+    public static String getCoverPicUrl(ParseUser pUser) {
+        String coverUrl = pUser.getString(PHOTO_URL);
         if (coverUrl == null || TextUtils.isEmpty(coverUrl)) {
             return "http://www.english-heritage.org.uk/content/properties/stonehenge/things-to-do/stonehenge-in-day";
         }
         return coverUrl;
     }
 
-    public void setCoverPicUrl(String coverPicUrl) {
-        put(PHOTO_URL, coverPicUrl);
+    public static void setCoverPicUrl(ParseUser pUser, String coverPicUrl) {
+        pUser.put(PHOTO_URL, coverPicUrl);
     }
 
-    public void queryTrips(FindCallback<Trip> callback) {
+    public static void queryTrips(ParseUser pUser, FindCallback<Trip> callback) {
         ParseQuery<Trip> query = ParseQuery.getQuery(Trip.class);
-        query.whereEqualTo(USER_KEY, this);
+        query.whereEqualTo(USER_KEY, pUser);
         query.findInBackground(callback);
     }
 
-    public ParseRelation<Trip> getFavoriteRelation() {
-        return getRelation(FAVORITES_RELATION_KEY);
+    public static ParseRelation<Trip> getFavoriteRelation(ParseUser pUser) {
+        return pUser.getRelation(FAVORITES_RELATION_KEY);
     }
 
-    public void addFavorite(Trip trip) {
-        getFavoriteRelation().add(trip);
-        saveInBackground();
+    public static void addFavorite(ParseUser pUser, Trip trip) {
+        getFavoriteRelation(pUser).add(trip);
     }
 
-    public void removeFavorite(Trip trip) {
-        getFavoriteRelation().remove(trip);
-        saveInBackground();
+    public static void removeFavorite(ParseUser pUser, Trip trip) {
+        getFavoriteRelation(pUser).remove(trip);
     }
 
-    public void queryFavorites(FindCallback<Trip> callback) {
-        getFavoriteRelation().getQuery().findInBackground(callback);
+    public static void queryFavorites(ParseUser pUser, FindCallback<Trip> callback) {
+        getFavoriteRelation(pUser).getQuery().findInBackground(callback);
     }
 
-    public ParseRelation<User> getFollowingRelation() {
-        return getRelation(FOLLOWING_RELATION_KEY);
+    public static ParseRelation<ParseUser> getFollowingRelation(ParseUser pUser) {
+        return pUser.getRelation(FOLLOWING_RELATION_KEY);
     }
 
-    public void follow(User user) {
-        getFollowingRelation().add(user);
-        saveInBackground();
+    public static void follow(ParseUser pUser, ParseUser otherUser) {
+        getFollowingRelation(pUser).add(otherUser);
     }
 
-    public void unFollow(User user) {
-        getFollowingRelation().remove(user);
-        saveInBackground();
+    public static void unFollow(ParseUser pUser, ParseUser otherUser) {
+        getFollowingRelation(pUser).remove(otherUser);
     }
 
-    public void queryFollowing(FindCallback<User> callback) {
-        getFollowingRelation().getQuery().findInBackground(callback);
+    public static void queryFollowing(ParseUser pUser, FindCallback<ParseUser> callback) {
+        getFollowingRelation(pUser).getQuery().findInBackground(callback);
     }
 
-    public void queryFollowers(FindCallback<User> callback) {
-        ParseQuery<User> query = ParseQuery.getQuery(USER_CLASS_NAME);
-        query.whereEqualTo(FOLLOWING_RELATION_KEY, this);
+    public static void queryFollowers(ParseUser pUser, FindCallback<ParseUser> callback) {
+        ParseQuery<ParseUser> query = ParseUser.getQuery();
+        query.whereEqualTo(FOLLOWING_RELATION_KEY, pUser);
         query.findInBackground(callback);
     }
 


### PR DESCRIPTION
Since it's recommended to not extend the ParseUser model, I've converted the User model to a helper class with static methods for accessing the additional fields and relations.

Now we'll always handle ParseUser objects instead of User objects.

To access extra fields you can use the helper methods and pass in the ParseUser like this:
```
ParseUser pUser = ParseUser.getCurrentUser();
String profilePicUrl = User.getProfilePicUrl(pUser);
```

Also fixes the app crashing when trying to signup a new ParseUser.