### PR TITLE
Add following timeline + random cleanup

### DIFF
--- a/app/src/main/java/com/codepath/travel/Constants.java
+++ b/app/src/main/java/com/codepath/travel/Constants.java
@@ -8,6 +8,9 @@ public final class Constants {
     public static final int CREATE_STORY_REQUEST = 1;
     public static final int AUTOCOMPLETE_REQUEST = 2;
     public static final int PLACE_DETAIL_REQUEST = 3;
+    public static final String APP_TAG = "TravelTrails";
+    public static final int START_CAMERA_REQUEST_CODE = 123;
+    public static final int PICK_IMAGE_FROM_GALLERY_CODE = 456;
 
     /* Intent argument keys */
     public static final String DESTINATION_ARG = "destination";
@@ -19,4 +22,10 @@ public final class Constants {
     public static final String PLACE_CATEGORY_ARG = "place_category";
     public static final String POSITION_ARG = "position";
     public static final String IS_STORY_PLACE = "isStoryPlace";
+
+    /* Story Activity argument keys */
+    public static final String TRIP_ID_ARG = "trip_id";
+    public static final String TRIP_TITLE_ARG = "trip_title";
+    public static final String IS_OWNER_ARG = "is_owner";
+
 }

--- a/app/src/main/java/com/codepath/travel/activities/ProfileViewActivity.java
+++ b/app/src/main/java/com/codepath/travel/activities/ProfileViewActivity.java
@@ -10,6 +10,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.codepath.travel.Constants;
 import com.codepath.travel.R;
 import com.codepath.travel.adapters.ProfilePagerAdapter;
 import com.codepath.travel.callbacks.ParseQueryCallback;
@@ -29,242 +30,243 @@ import butterknife.BindView;
  */
 
 public class ProfileViewActivity
-  extends BaseActivity
-  implements ImagePickerFragment.ImagePickerFragmentListener, TripClickListener {
+    extends BaseActivity
+    implements ImagePickerFragment.ImagePickerFragmentListener, TripClickListener {
 
-  private static final String TAG = ProfileViewActivity.class.getSimpleName();
+    private static final String TAG = ProfileViewActivity.class.getSimpleName();
 
-  // Intent variables
-  public static final String USER_ID = "user_id";
+    // Intent variables
+    public static final String USER_ID = "user_id";
 
-  // Image Picker Fragment Tags
-  private static final String COVER_PIC = "cover_pic";
-  private static final String PROFILE_PIC = "profile_pic";
+    // Image Picker Fragment Tags
+    private static final String COVER_PIC = "cover_pic";
+    private static final String PROFILE_PIC = "profile_pic";
 
-  // views
-  @BindView(R.id.tvProfileUserName) TextView tvProfileUserName;
-  @BindView(R.id.tabLayout) TabLayout tabLayout;
-  @BindView(R.id.tabViewPager) ViewPager tabViewPager;
-  @BindView(R.id.ivFollowUser) ImageView ivFollowUser;
-  @BindView(R.id.tvFollowersCount) TextView tvFollowersCount;
-  @BindView(R.id.tvFollowingCount) TextView tvFollowingCount;
+    // views
+    @BindView(R.id.tvProfileUserName) TextView tvProfileUserName;
+    @BindView(R.id.tabLayout) TabLayout tabLayout;
+    @BindView(R.id.tabViewPager) ViewPager tabViewPager;
+    @BindView(R.id.ivFollowUser) ImageView ivFollowUser;
+    @BindView(R.id.tvFollowersCount) TextView tvFollowersCount;
+    @BindView(R.id.tvFollowingCount) TextView tvFollowingCount;
 
-  // member variables
-  private ParseUser mUser;
+    // member variables
+    private ParseUser mUser;
 
-  @Override
-  public void onCreate(Bundle savedInstance) {
-    super.onCreate(savedInstance);
-    setContentView(R.layout.activity_user_profile);
-    initializeCommonViews();
-    String userID = getIntent().getStringExtra(USER_ID);
+    @Override
+    public void onCreate(Bundle savedInstance) {
+        super.onCreate(savedInstance);
+        setContentView(R.layout.activity_user_profile);
+        initializeCommonViews();
+        String userID = getIntent().getStringExtra(USER_ID);
 
-    // prefer early return over if/else blocks
-    if (!getIsValidUser(userID)) {
-      showError("invalid user id passed");
-      return;
-    }
-
-    // get the user and load all fragments
-    User.getUserByID(userID, new ParseQueryCallback<ParseUser>() {
-      @Override
-      public void onQuerySuccess(ParseUser data) {
-        mUser = data;
-        initializeViews(data);
-        initializeAllFragments(data);
-      }
-
-      @Override
-      public void onQueryError(ParseException e) {
-        showError("error fetching user");
-      }
-    });
-  }
-
-  @Override
-  public void onImageUploadSuccess(final String tag, final String imageURL) {
-    ImagePickerFragment imagePicker =
-      (ImagePickerFragment) (getSupportFragmentManager().findFragmentByTag(tag));
-    switch (tag) {
-      case COVER_PIC:
-        User.saveCoverPicURL(mUser, imageURL, new ParseQueryCallback<ParseUser>() {
-          @Override
-          public void onQuerySuccess(ParseUser data) {
-            // load the image in the fragment
-            imagePicker.loadImage(imageURL);
-          }
-
-          @Override
-          public void onQueryError(ParseException e) {
-            // TODO hook this to the fragment
-            showError("Cover Pic Failed");
-          }
-        });
-        break;
-      case PROFILE_PIC:
-        User.saveProfilePicURL(mUser, imageURL, new ParseQueryCallback<ParseUser>() {
-          @Override
-          public void onQuerySuccess(ParseUser data) {
-            // load the image in the fragment
-            imagePicker.loadImage(imageURL);
-          }
-
-          @Override
-          public void onQueryError(ParseException e) {
-            // TODO hook this to the fragment
-            showError("Profile Pic Failed");
-          }
-        });
-        break;
-    }
-  }
-
-  @Override
-  public void onTripClick(String tripId, String tripTitle) {
-    Intent openStory = new Intent(ProfileViewActivity.this, StoryActivity.class);
-    openStory.putExtra(StoryActivity.TRIP_TITLE_ARG, tripTitle);
-    openStory.putExtra(StoryActivity.TRIP_ID_ARG, tripId);
-    startActivity(openStory);
-  }
-
-  @Override
-  public void onShareClick(Trip trip, boolean share) {
-    boolean isShared = trip.isShared();
-    if (!isShared && share) {
-      trip.setShared(true);
-    } else if (isShared && !share) {
-      trip.setShared(false);
-    }
-    trip.saveInBackground();
-  }
-
-  @Override
-  public void onProfileClick(ParseUser pUser) {
-    Toast.makeText(this, "onProfileClick", Toast.LENGTH_SHORT).show();
-  }
-
-  // all private methods below
-
-  private void initializeViews(ParseUser user) {
-    tvProfileUserName.setText(user.getUsername());
-
-    setActionBarTitle(user.getUsername());
-
-    tabViewPager.setAdapter(
-      new ProfilePagerAdapter(
-        getSupportFragmentManager(),
-        this,
-        user.getObjectId()
-      )
-    );
-    tabLayout.setupWithViewPager(tabViewPager);
-
-    initFollowers(user);
-    initFollowing(user);
-
-    tvFollowersCount.setOnClickListener((View v) -> {
-      Intent showFollowers = new Intent(ProfileViewActivity.this, FollowActivity.class);
-      showFollowers.putExtra(FollowActivity.SHOW_FOLLOWERS, true);
-      showFollowers.putExtra(FollowActivity.USER_ID, user.getObjectId());
-      startActivity(showFollowers);
-    });
-
-    tvFollowingCount.setOnClickListener((View v) -> {
-      Intent showFollowers = new Intent(ProfileViewActivity.this, FollowActivity.class);
-      showFollowers.putExtra(FollowActivity.SHOW_FOLLOWERS, false);
-      showFollowers.putExtra(FollowActivity.USER_ID, user.getObjectId());
-      startActivity(showFollowers);
-    });
-
-    // user can't follow himself
-    if (ParseUser.getCurrentUser().getObjectId().equals(user.getObjectId())) {
-      return;
-    }
-
-    ivFollowUser.setVisibility(View.VISIBLE);
-
-    // make query to check following relation
-    User.queryIsFollowing(ParseUser.getCurrentUser(), user, (List<ParseUser> objects, ParseException e) -> {
-      // successfull query with size > 0 indicates we have a relation
-      if (e == null && objects.size() > 0) {
-        setFollowRelationImageResource(ivFollowUser, user, R.drawable.ic_person_friend);
-        return;
-      }
-      setFollowRelationImageResource(ivFollowUser, user, R.drawable.ic_person_add);
-    });
-  }
-
-   private void initializeAllFragments(ParseUser user) {
-    FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
-
-    fragmentTransaction.replace(
-      R.id.flCoverPicContainer,
-      ImagePickerFragment.newInstance(User.getCoverPicUrl(user), user.getObjectId()),
-      COVER_PIC
-    );
-
-     fragmentTransaction.replace(
-      R.id.flUserPicContainer,
-      ImagePickerFragment.newInstance(User.getProfilePicUrl(user), user.getObjectId()),
-      PROFILE_PIC
-     );
-
-    fragmentTransaction.commit();
-  }
-
-  private boolean getIsValidUser(String userID) {
-    return userID.trim().length() > 0 && (userID != null);
-  }
-
-  private void initFollowers(ParseUser user) {
-    User.queryAllFollowers(user, (List<ParseUser> followers, ParseException e) -> {
-      if (e == null) {
-        tvFollowersCount.setText(followers.size()+"");
-      }
-    });
-  }
-
-  private void initFollowing(ParseUser user) {
-    User.queryAllFollowing(user, (List<ParseUser> following, ParseException e) -> {
-      if (e == null) {
-        tvFollowingCount.setText(following.size()+"");
-      }
-    });
-
-  }
-
-  // this stuff is the same as user adapter follow
-  // fragments within a fragment does not seem like a good idea
-  // need to figure out how to share this between user adapter and profile
-  private void setFollowRelationImageResource(ImageView imageView, ParseUser user, int resource) {
-    imageView.setVisibility(View.VISIBLE);
-    imageView.setImageResource(resource);
-    if (resource == R.drawable.ic_person_friend) {
-      setUnFollowListener(imageView, user);
-      return;
-    }
-    setFollowListener(imageView, user);
-  }
-
-  private void setUnFollowListener(ImageView imageView, ParseUser otherUser) {
-    imageView.setOnClickListener((View v) -> {
-      User.unFollow(ParseUser.getCurrentUser(), otherUser, (ParseException e) -> {
-        if (e == null) {
-          setFollowRelationImageResource(imageView, otherUser, R.drawable.ic_person_add);
-          initFollowers(otherUser);
+        // prefer early return over if/else blocks
+        if (!getIsValidUser(userID)) {
+            showError("invalid user id passed");
+            return;
         }
-      });
-    });
-  }
 
-  private void setFollowListener(ImageView imageView, ParseUser otherUser) {
-    imageView.setOnClickListener((View v) -> {
-      User.follow(ParseUser.getCurrentUser(), otherUser, (ParseException e) -> {
-        if (e == null) {
-          setFollowRelationImageResource(imageView, otherUser, R.drawable.ic_person_friend);
-          initFollowers(otherUser);
+        // get the user and load all fragments
+        User.getUserByID(userID, new ParseQueryCallback<ParseUser>() {
+            @Override
+            public void onQuerySuccess(ParseUser data) {
+                mUser = data;
+                initializeViews(data);
+                initializeAllFragments(data);
+            }
+
+            @Override
+            public void onQueryError(ParseException e) {
+                showError("error fetching user");
+            }
+        });
+    }
+
+    @Override
+    public void onImageUploadSuccess(final String tag, final String imageURL) {
+        ImagePickerFragment imagePicker =
+            (ImagePickerFragment) (getSupportFragmentManager().findFragmentByTag(tag));
+        switch (tag) {
+            case COVER_PIC:
+                User.saveCoverPicURL(mUser, imageURL, new ParseQueryCallback<ParseUser>() {
+                    @Override
+                    public void onQuerySuccess(ParseUser data) {
+                        // load the image in the fragment
+                        imagePicker.loadImage(imageURL);
+                    }
+
+                    @Override
+                    public void onQueryError(ParseException e) {
+                        // TODO hook this to the fragment
+                        showError("Cover Pic Failed");
+                    }
+                });
+                break;
+            case PROFILE_PIC:
+                User.saveProfilePicURL(mUser, imageURL, new ParseQueryCallback<ParseUser>() {
+                    @Override
+                    public void onQuerySuccess(ParseUser data) {
+                        // load the image in the fragment
+                        imagePicker.loadImage(imageURL);
+                    }
+
+                    @Override
+                    public void onQueryError(ParseException e) {
+                        // TODO hook this to the fragment
+                        showError("Profile Pic Failed");
+                    }
+                });
+                break;
         }
-      });
-    });
-  }
+    }
+
+    @Override
+    public void onTripClick(String tripId, String tripTitle, boolean isOwner) {
+        Intent openStory = new Intent(ProfileViewActivity.this, StoryActivity.class);
+        openStory.putExtra(Constants.TRIP_TITLE_ARG, tripTitle);
+        openStory.putExtra(Constants.TRIP_ID_ARG, tripId);
+        openStory.putExtra(Constants.IS_OWNER_ARG, isOwner);
+        startActivity(openStory);
+    }
+
+    @Override
+    public void onShareClick(Trip trip, boolean share) {
+        boolean isShared = trip.isShared();
+        if (!isShared && share) {
+            trip.setShared(true);
+        } else if (isShared && !share) {
+            trip.setShared(false);
+        }
+        trip.saveInBackground();
+    }
+
+    @Override
+    public void onProfileClick(ParseUser pUser) {
+        // do nothing
+    }
+
+    // all private methods below
+
+    private void initializeViews(ParseUser user) {
+        tvProfileUserName.setText(user.getUsername());
+
+        setActionBarTitle(user.getUsername());
+
+        tabViewPager.setAdapter(
+            new ProfilePagerAdapter(
+                getSupportFragmentManager(),
+                this,
+                user.getObjectId()
+            )
+        );
+        tabLayout.setupWithViewPager(tabViewPager);
+
+        initFollowers(user);
+        initFollowing(user);
+
+        tvFollowersCount.setOnClickListener((View v) -> {
+            Intent showFollowers = new Intent(ProfileViewActivity.this, FollowActivity.class);
+            showFollowers.putExtra(FollowActivity.SHOW_FOLLOWERS, true);
+            showFollowers.putExtra(FollowActivity.USER_ID, user.getObjectId());
+            startActivity(showFollowers);
+        });
+
+        tvFollowingCount.setOnClickListener((View v) -> {
+            Intent showFollowers = new Intent(ProfileViewActivity.this, FollowActivity.class);
+            showFollowers.putExtra(FollowActivity.SHOW_FOLLOWERS, false);
+            showFollowers.putExtra(FollowActivity.USER_ID, user.getObjectId());
+            startActivity(showFollowers);
+        });
+
+        // user can't follow himself
+        if (ParseUser.getCurrentUser().getObjectId().equals(user.getObjectId())) {
+            return;
+        }
+
+        ivFollowUser.setVisibility(View.VISIBLE);
+
+        // make query to check following relation
+        User.queryIsFollowing(ParseUser.getCurrentUser(), user, (List<ParseUser> objects, ParseException e) -> {
+            // successfull query with size > 0 indicates we have a relation
+            if (e == null && objects.size() > 0) {
+                setFollowRelationImageResource(ivFollowUser, user, R.drawable.ic_person_friend);
+                return;
+            }
+            setFollowRelationImageResource(ivFollowUser, user, R.drawable.ic_person_add);
+        });
+    }
+
+     private void initializeAllFragments(ParseUser user) {
+        FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
+
+        fragmentTransaction.replace(
+            R.id.flCoverPicContainer,
+            ImagePickerFragment.newInstance(User.getCoverPicUrl(user), user.getObjectId()),
+            COVER_PIC
+        );
+
+         fragmentTransaction.replace(
+            R.id.flUserPicContainer,
+            ImagePickerFragment.newInstance(User.getProfilePicUrl(user), user.getObjectId()),
+            PROFILE_PIC
+         );
+
+        fragmentTransaction.commit();
+    }
+
+    private boolean getIsValidUser(String userID) {
+        return userID.trim().length() > 0 && (userID != null);
+    }
+
+    private void initFollowers(ParseUser user) {
+        User.queryAllFollowers(user, (List<ParseUser> followers, ParseException e) -> {
+            if (e == null) {
+                tvFollowersCount.setText(followers.size()+"");
+            }
+        });
+    }
+
+    private void initFollowing(ParseUser user) {
+        User.queryAllFollowing(user, (List<ParseUser> following, ParseException e) -> {
+            if (e == null) {
+                tvFollowingCount.setText(following.size()+"");
+            }
+        });
+
+    }
+
+    // this stuff is the same as user adapter follow
+    // fragments within a fragment does not seem like a good idea
+    // need to figure out how to share this between user adapter and profile
+    private void setFollowRelationImageResource(ImageView imageView, ParseUser user, int resource) {
+        imageView.setVisibility(View.VISIBLE);
+        imageView.setImageResource(resource);
+        if (resource == R.drawable.ic_person_friend) {
+            setUnFollowListener(imageView, user);
+            return;
+        }
+        setFollowListener(imageView, user);
+    }
+
+    private void setUnFollowListener(ImageView imageView, ParseUser otherUser) {
+        imageView.setOnClickListener((View v) -> {
+            User.unFollow(ParseUser.getCurrentUser(), otherUser, (ParseException e) -> {
+                if (e == null) {
+                    setFollowRelationImageResource(imageView, otherUser, R.drawable.ic_person_add);
+                    initFollowers(otherUser);
+                }
+            });
+        });
+    }
+
+    private void setFollowListener(ImageView imageView, ParseUser otherUser) {
+        imageView.setOnClickListener((View v) -> {
+            User.follow(ParseUser.getCurrentUser(), otherUser, (ParseException e) -> {
+                if (e == null) {
+                    setFollowRelationImageResource(imageView, otherUser, R.drawable.ic_person_friend);
+                    initFollowers(otherUser);
+                }
+            });
+        });
+    }
 }

--- a/app/src/main/java/com/codepath/travel/activities/StoryCollageActivity.java
+++ b/app/src/main/java/com/codepath/travel/activities/StoryCollageActivity.java
@@ -1,7 +1,7 @@
 package com.codepath.travel.activities;
 
-import static com.codepath.travel.activities.StoryActivity.TRIP_ID_ARG;
-import static com.codepath.travel.activities.StoryActivity.TRIP_TITLE_ARG;
+import static com.codepath.travel.Constants.TRIP_ID_ARG;
+import static com.codepath.travel.Constants.TRIP_TITLE_ARG;
 
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
@@ -58,7 +58,7 @@ public class StoryCollageActivity extends AppCompatActivity {
         mTripID = getIntent().getStringExtra(TRIP_ID_ARG);
 
         mStoryPlaces = new ArrayList<>();
-        Trip.getPlaces(mTripID, new FindCallback<StoryPlace>() {
+        Trip.getPlacesForTripId(mTripID, new FindCallback<StoryPlace>() {
             @Override
             public void done(List<StoryPlace> places, ParseException e) {
                 if (e == null) {

--- a/app/src/main/java/com/codepath/travel/adapters/HomePagerAdapter.java
+++ b/app/src/main/java/com/codepath/travel/adapters/HomePagerAdapter.java
@@ -5,51 +5,64 @@ import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
 
-import com.codepath.travel.fragments.CurrentTripListFragment;
-import com.codepath.travel.fragments.PastTripListFragment;
-import com.codepath.travel.fragments.PlannedTripListFragment;
+import com.codepath.travel.fragments.FollowingTripListFragment;
 import com.codepath.travel.fragments.TripListFragment;
 
 /**
- * Created by rpraveen on 11/19/16.
+ * Pager adapter for the home view.
  */
-
 public class HomePagerAdapter extends FragmentPagerAdapter {
 
-  // member variables
-  private Context mContext;
-  private String [] mTabs = {"Current Trips", "Past Trips", "Future Trips"};
-  private String mUserID;
+    // member variables
+    private Context mContext;
+    private String [] mTabs = { "Trip Feed", "My Trips" };
+    private String mUserID;
+    private FollowingTripListFragment followingFragment;
+    private TripListFragment myTripsFragment;
 
-  public HomePagerAdapter(FragmentManager fragmentManager, Context context, String userID) {
-    super(fragmentManager);
-    mContext = context;
-    mUserID = userID;
-  }
-
-  @Override
-  public Fragment getItem(int position) {
-    if (position == 0) {
-      return CurrentTripListFragment.newInstance(mUserID, false);
-    } else if (position == 1) {
-      return PastTripListFragment.newInstance(mUserID, false);
-    } else {
-      return PlannedTripListFragment.newInstance(mUserID, false);
+    public HomePagerAdapter(FragmentManager fragmentManager, Context context, String userID) {
+        super(fragmentManager);
+        mContext = context;
+        mUserID = userID;
     }
-  }
 
-  @Override
-  public int getCount() {
-    return mTabs.length;
-  }
+    @Override
+    public Fragment getItem(int position) {
+        if (position == 0) {
+            if (followingFragment == null) {
+                followingFragment = FollowingTripListFragment.newInstance(mUserID);
+            }
+            return followingFragment;
+        } else {
+            if (myTripsFragment == null) {
+                myTripsFragment = TripListFragment.newInstance(mUserID, false, true);
+            }
+            return myTripsFragment;
+        }
+    }
 
-  @Override
-  public CharSequence getPageTitle(int position) {
-    // Generate title based on item position
-    return mTabs[position];
-  }
+    @Override
+    public int getCount() {
+        return mTabs.length;
+    }
 
-  public int getItemPosition(Object object){
-    return POSITION_NONE;
-  }
+    @Override
+    public CharSequence getPageTitle(int position) {
+        // Generate title based on item position
+        return mTabs[position];
+    }
+
+    public int getItemPosition(Object object){
+        return POSITION_NONE;
+    }
+
+    public void setUser(String userId) {
+        mUserID = userId;
+        if (followingFragment != null) {
+            followingFragment.setUser(userId);
+        }
+        if (myTripsFragment != null) {
+            myTripsFragment.setUser(userId);
+        }
+    }
 }

--- a/app/src/main/java/com/codepath/travel/adapters/ProfilePagerAdapter.java
+++ b/app/src/main/java/com/codepath/travel/adapters/ProfilePagerAdapter.java
@@ -6,42 +6,41 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
 
 import com.codepath.travel.fragments.PastTripListFragment;
-import com.codepath.travel.fragments.PlannedTripListFragment;
+import com.codepath.travel.fragments.UpcomingTripListFragment;
 
 /**
- * Created by rpraveen on 11/19/16.
+ * Pager adapter for displaying trips on a user's profile.
  */
-
 public class ProfilePagerAdapter extends FragmentPagerAdapter {
 
-  // member variables
-  private Context mContext;
-  private String [] mTabs = {"Past Trips", "Future Trips"};
-  private String mUserID;
+    // member variables
+    private Context mContext;
+    private String [] mTabs = {"Past Trips", "Upcoming Trips"};
+    private String mUserID;
 
-  public ProfilePagerAdapter(FragmentManager fragmentManager, Context context, String userID) {
-    super(fragmentManager);
-    mContext = context;
-    mUserID = userID;
-  }
-
-  @Override
-  public Fragment getItem(int position) {
-    if (position == 0) {
-      return PastTripListFragment.newInstance(mUserID, false);
-    } else {
-      return PlannedTripListFragment.newInstance(mUserID, false);
+    public ProfilePagerAdapter(FragmentManager fragmentManager, Context context, String userID) {
+        super(fragmentManager);
+        mContext = context;
+        mUserID = userID;
     }
-  }
 
-  @Override
-  public int getCount() {
-    return mTabs.length;
-  }
+    @Override
+    public Fragment getItem(int position) {
+        if (position == 0) {
+            return PastTripListFragment.newInstance(mUserID, false);
+        } else {
+            return UpcomingTripListFragment.newInstance(mUserID, false);
+        }
+    }
 
-  @Override
-  public CharSequence getPageTitle(int position) {
-    // Generate title based on item position
-    return mTabs[position];
-  }
+    @Override
+    public int getCount() {
+        return mTabs.length;
+    }
+
+    @Override
+    public CharSequence getPageTitle(int position) {
+        // Generate title based on item position
+        return mTabs[position];
+    }
 }

--- a/app/src/main/java/com/codepath/travel/adapters/TripsAdapter.java
+++ b/app/src/main/java/com/codepath/travel/adapters/TripsAdapter.java
@@ -14,7 +14,6 @@ import com.codepath.travel.fragments.TripClickListener;
 import com.codepath.travel.helper.DateUtils;
 import com.codepath.travel.helper.ImageUtils;
 import com.codepath.travel.models.parse.Trip;
-import com.parse.ParseUser;
 
 import java.util.List;
 
@@ -29,13 +28,15 @@ public class TripsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
 
     private List<Trip> mTrips;
     private Context mContext;
-    private boolean showProfilePhoto;
     private TripClickListener listener;
+    private boolean showProfilePhoto;
+    private boolean showSharing;
 
-    public TripsAdapter(Context context, List<Trip> trips, boolean showProfilePhoto) {
+    public TripsAdapter(Context context, List<Trip> trips, boolean showProfilePhoto, boolean showSharing) {
         this.mTrips = trips;
         this.mContext = context;
         this.showProfilePhoto = showProfilePhoto;
+        this.showSharing = showSharing;
         this.listener = (TripClickListener) context;
     }
 
@@ -64,6 +65,7 @@ public class TripsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                 R.drawable.ic_photoholder,
                 viewHolder.getProgressBar());
 
+        // profile photo (currently for following tab only)
         ImageView ivProfilePhoto = viewHolder.getProfilePhoto();
         if (showProfilePhoto) {
             ImageUtils.loadImageCircle(ivProfilePhoto, getProfilePicUrl(trip.getUser()),
@@ -77,8 +79,9 @@ public class TripsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         TextView tvTripDates = viewHolder.getTripDates();
         tvTripDates.setText(DateUtils.formatDateRange(mContext, trip.getStartDate(), trip.getEndDate()));
 
+        // sharing checkbox (currently for my trips tab only)
         CheckBox cbShare = viewHolder.cbShare;
-        if (ParseUser.getCurrentUser().getObjectId().equals(trip.getUser().getObjectId())) {
+        if (showSharing) {
             cbShare.setVisibility(View.VISIBLE);
             cbShare.setChecked(trip.isShared());
             cbShare.setOnCheckedChangeListener(

--- a/app/src/main/java/com/codepath/travel/fragments/CurrentTripListFragment.java
+++ b/app/src/main/java/com/codepath/travel/fragments/CurrentTripListFragment.java
@@ -9,23 +9,17 @@ import com.codepath.travel.models.parse.Trip;
  */
 public class CurrentTripListFragment extends TripListFragment {
 
-    public static CurrentTripListFragment newInstance(String userId, boolean fetchUser) {
+    public static CurrentTripListFragment newInstance(String userId, boolean showUser) {
         CurrentTripListFragment fragment = new CurrentTripListFragment();
         Bundle args = new Bundle();
         args.putString(USER_ID_ARG, userId);
-        args.putBoolean(FETCH_USER_ARG, fetchUser);
+        args.putBoolean(SHOW_USER_ARG, showUser);
         fragment.setArguments(args);
         return fragment;
     }
 
     @Override
-    public void populateTrips() {
-        if (mUserId == null) {
-            return;
-        }
-        mTrips.clear();
-        Trip.getCurrentTripsForUser(mUserId, fetchUser, (trips, e) -> {
-            resetTripAdapter(trips, e);
-        });
+    public void getTrips() {
+        Trip.getCurrentTripsForUser(mUserId, showUser, this::updateTrips);
     }
 }

--- a/app/src/main/java/com/codepath/travel/fragments/FollowingTripListFragment.java
+++ b/app/src/main/java/com/codepath/travel/fragments/FollowingTripListFragment.java
@@ -1,0 +1,27 @@
+package com.codepath.travel.fragments;
+
+import android.os.Bundle;
+
+import com.codepath.travel.models.parse.Trip;
+
+/**
+ * Fragment to display a recycler view of followed users' trips.
+ */
+public class FollowingTripListFragment extends TripListFragment {
+
+    public static FollowingTripListFragment newInstance(String userId) {
+        FollowingTripListFragment fragment = new FollowingTripListFragment();
+        Bundle args = new Bundle();
+        args.putString(USER_ID_ARG, userId);
+        args.putBoolean(SHOW_USER_ARG, true);
+        args.putBoolean(SHOW_SHARING_ARG, false);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void getTrips() {
+        Trip.getFollowingTrips(mUserId, this::updateTrips);
+    }
+
+}

--- a/app/src/main/java/com/codepath/travel/fragments/PastTripListFragment.java
+++ b/app/src/main/java/com/codepath/travel/fragments/PastTripListFragment.java
@@ -9,23 +9,17 @@ import com.codepath.travel.models.parse.Trip;
  */
 public class PastTripListFragment extends TripListFragment {
 
-    public static PastTripListFragment newInstance(String userId, boolean fetchUser) {
+    public static PastTripListFragment newInstance(String userId, boolean showUser) {
         PastTripListFragment fragment = new PastTripListFragment();
         Bundle args = new Bundle();
         args.putString(USER_ID_ARG, userId);
-        args.putBoolean(FETCH_USER_ARG, fetchUser);
+        args.putBoolean(SHOW_USER_ARG, showUser);
         fragment.setArguments(args);
         return fragment;
     }
 
     @Override
-    public void populateTrips() {
-        if (mUserId == null) {
-            return;
-        }
-        mTrips.clear();
-        Trip.getPastTripsForUser(mUserId, fetchUser, (trips, e) -> {
-            resetTripAdapter(trips, e);
-        });
+    public void getTrips() {
+        Trip.getPastTripsForUser(mUserId, showUser, this::updateTrips);
     }
 }

--- a/app/src/main/java/com/codepath/travel/fragments/PlannedTripListFragment.java
+++ b/app/src/main/java/com/codepath/travel/fragments/PlannedTripListFragment.java
@@ -10,23 +10,17 @@ import com.codepath.travel.models.parse.Trip;
 public class PlannedTripListFragment extends TripListFragment {
     private static final String TAG = PlannedTripListFragment.class.getSimpleName();
 
-    public static PlannedTripListFragment newInstance(String userId, boolean fetchUser) {
+    public static PlannedTripListFragment newInstance(String userId, boolean showUser) {
         PlannedTripListFragment fragment = new PlannedTripListFragment();
         Bundle args = new Bundle();
         args.putString(USER_ID_ARG, userId);
-        args.putBoolean(FETCH_USER_ARG, fetchUser);
+        args.putBoolean(SHOW_USER_ARG, showUser);
         fragment.setArguments(args);
         return fragment;
     }
 
     @Override
-    public void populateTrips() {
-        if (mUserId == null) {
-            return;
-        }
-        mTrips.clear();
-        Trip.getPlannedTripsForUser(mUserId, fetchUser, (trips, e) -> {
-            resetTripAdapter(trips, e);
-        });
+    public void getTrips() {
+        Trip.getPlannedTripsForUser(mUserId, showUser, this::updateTrips);
     }
 }

--- a/app/src/main/java/com/codepath/travel/fragments/TripClickListener.java
+++ b/app/src/main/java/com/codepath/travel/fragments/TripClickListener.java
@@ -7,7 +7,7 @@ import com.parse.ParseUser;
  * Interface for trip item clicks listener.
  */
 public interface TripClickListener {
-    void onTripClick(String tripId, String tripTitle);
+    void onTripClick(String tripId, String tripTitle, boolean isOwner);
     void onShareClick(Trip trip, boolean share);
     void onProfileClick(ParseUser pUser);
 }

--- a/app/src/main/java/com/codepath/travel/fragments/UpcomingTripListFragment.java
+++ b/app/src/main/java/com/codepath/travel/fragments/UpcomingTripListFragment.java
@@ -1,0 +1,26 @@
+package com.codepath.travel.fragments;
+
+import android.os.Bundle;
+
+import com.codepath.travel.models.parse.Trip;
+
+/**
+ * Fragment to display a recycler view of upcoming trips.
+ */
+public class UpcomingTripListFragment extends TripListFragment {
+    private static final String TAG = UpcomingTripListFragment.class.getSimpleName();
+
+    public static UpcomingTripListFragment newInstance(String userId, boolean showUser) {
+        UpcomingTripListFragment fragment = new UpcomingTripListFragment();
+        Bundle args = new Bundle();
+        args.putString(USER_ID_ARG, userId);
+        args.putBoolean(SHOW_USER_ARG, showUser);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void getTrips() {
+        Trip.getUpcomingTripsForUser(mUserId, showUser, this::updateTrips);
+    }
+}

--- a/app/src/main/java/com/codepath/travel/fragments/dialog/EditMediaDialogFragment.java
+++ b/app/src/main/java/com/codepath/travel/fragments/dialog/EditMediaDialogFragment.java
@@ -52,7 +52,7 @@ public class EditMediaDialogFragment extends DialogFragment {
 
     public interface EditMediaListener {
         void onSaveCaption(int position, String caption, String mediaId);
-        void onDelete(int position, String mediaId);
+        void onDeleteMedia(int position, String mediaId);
         void onSetStoryPlaceCoverPhoto(int position, String coverUrl);
         void onSetTripCoverPhoto(String coverUrl);
         void onSetUserCoverPhoto(String coverUrl);
@@ -128,7 +128,7 @@ public class EditMediaDialogFragment extends DialogFragment {
             });
 
             btnDelete.setOnClickListener(v -> {
-                listener.onDelete(position, mediaId);
+                listener.onDeleteMedia(position, mediaId);
                 dismiss();
             });
         } else {

--- a/app/src/main/res/drawable/ic_home.xml
+++ b/app/src/main/res/drawable/ic_home.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="@dimen/icon_size"
+        android:height="@dimen/icon_size"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:pathData="M10,20v-6h4v6h5v-8h3L12,3 2,12h3v8z"
+        android:fillColor="@color/lightGray"/>
+</vector>

--- a/app/src/main/res/drawable/ic_logout.xml
+++ b/app/src/main/res/drawable/ic_logout.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,3C20.11,3 21,3.9 21,5L21,8L19,8L19,5L5,5L5,19L19,19L19,16L21,16L21,19C21,20.1 20.11,21 19,21L5,21C3.9,21 3,20.1 3,19L3,5C3,3.9 3.9,3 5,3L19,3ZM15.5,17L20.5,12L15.5,7L14.09,8.41L16.67,11L7,11L7,13L16.67,13L14.09,15.59L15.5,17Z"/>
+</vector>

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -21,11 +21,11 @@
             app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
             android:background="?attr/colorPrimaryDark">
                 <fragment
-                android:id="@+id/autocomplete_fragment_new_trip"
-                android:name="com.codepath.travel.fragments.CustomPlaceAutoCompleteFragment"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                />
+                    android:id="@+id/autocomplete_fragment_new_trip"
+                    android:name="com.codepath.travel.fragments.CustomPlaceAutoCompleteFragment"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    tools:layout="@layout/layout_place_autocomplete" />
         </android.support.v7.widget.Toolbar>
 
         <include

--- a/app/src/main/res/layout/layout_tabs.xml
+++ b/app/src/main/res/layout/layout_tabs.xml
@@ -4,14 +4,16 @@
               android:orientation="vertical"
               android:layout_width="match_parent"
               android:layout_height="match_parent">
+
     <android.support.design.widget.TabLayout
         android:id="@+id/tabLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:tabMode="fixed"/>
+
     <android.support.v4.view.ViewPager
         android:id="@+id/tabViewPager"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         android:layout_weight="1"/>
 </LinearLayout>

--- a/app/src/main/res/menu/drawer_view.xml
+++ b/app/src/main/res/menu/drawer_view.xml
@@ -1,21 +1,25 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <group android:checkableBehavior="single">
+    <group android:checkableBehavior="none">
+        <item
+            android:id="@+id/nav_home"
+            android:icon="@drawable/ic_home"
+            android:title="@string/nav_home" />
         <item
             android:id="@+id/nav_profile"
-            android:icon="@android:drawable/ic_menu_info_details"
+            android:icon="@drawable/ic_info"
             android:title="@string/nav_profile" />
         <item
             android:id="@+id/nav_search"
             android:icon="@drawable/places_ic_search"
-            android:title="Search" />
+            android:title="@string/nav_find_users" />
         <item
             android:id="@+id/nav_logout"
-            android:icon="@drawable/com_facebook_button_like_icon_selected"
-            android:title="Logout" />
+            android:icon="@drawable/ic_logout"
+            android:title="@string/nav_logout" />
         <item
             android:id="@+id/nav_delete_account"
-            android:icon="@drawable/com_parse_ui_facebook_login_logo"
-            android:title="Delete Account" />
+            android:icon="@drawable/ic_delete"
+            android:title="@string/nav_delete" />
     </group>
 </menu>

--- a/app/src/main/res/menu/menu_story.xml
+++ b/app/src/main/res/menu/menu_story.xml
@@ -3,13 +3,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:context=".activities.PlaceSuggestionActivity">
 
-    <!--<item-->
-        <!--android:id="@+id/miMap"-->
-        <!--android:orderInCategory="10"-->
-        <!--android:title="@string/view_map"-->
-        <!--android:icon="@android:drawable/ic_dialog_map"-->
-        <!--app:showAsAction="ifRoom" />-->
-
     <item
         android:id="@+id/miCollage"
         android:orderInCategory="20"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,9 +3,7 @@
     <string name="parse_app_id">traveltrails</string>
     <string name="google_api_key">AIzaSyCOhSebiVixAE8Aq5atvtzWJAhHuZH5l_U</string>
     <string name="facebook_app_id">646488778862200</string>
-    <!-- Account Management -->
-    <string name="logout">Logout</string>
-    <string name="deleteAccount">Delete Account</string>
+
     <!-- App related strings -->
     <string name="app_name">Travel</string>
     <string name="confirm_story">confirm to create story</string>
@@ -24,6 +22,11 @@
     <!-- Navigation drawer -->
     <string name="drawer_open">Open navigation drawer</string>
     <string name="drawer_close">Close navigation drawer</string>
+    <string name="nav_home">Home</string>
+    <string name="nav_profile">My Profile</string>
+    <string name="nav_find_users">Search Users</string>
+    <string name="nav_logout">Logout</string>
+    <string name="nav_delete">Delete Account</string>
 
     <!-- Group strings by activity -->
 
@@ -33,9 +36,6 @@
     <string name="planned_trips">Planned Trips</string>
     <string name="past_trips">Past Trips</string>
     <string name="current_trip">Current Trip</string>
-
-    <!-- Navigation View Strings -->
-    <string name="nav_profile">Profile</string>
 
     <!-- Search User DialogFrgament -->
     <string name="search_user">Find Friends</string>


### PR DESCRIPTION
Issue: #76 

Added new trip fragments:
* `FollowingTripsFragment` (for home activity, shows all shared trips by people I'm following)
* `UpcomingTripsFragment` (for profile activity, shows upcoming trips, i.e. current and future trips)

Fixed broken loading of tab data (logging out and logging in as different user did not properly refresh the tab data for the new logged in user).

Cleaned up the Navigation Drawer:
* changed checkableBehavior to none so the menu items aren't highlighted (looks weird when you open up the nav drawer and a previous menu item is highlighted)
* set icons
* updated delete code to actually delete user's data

StoryActivity:
* change toolbar menu options in onPrepareOptionsMenu, so that we hide the delete menu item for when viewing other users' stories



