### PR TITLE
Styling of trip feed

### DIFF
--- a/app/src/main/java/com/codepath/travel/adapters/TripViewHolder.java
+++ b/app/src/main/java/com/codepath/travel/adapters/TripViewHolder.java
@@ -23,6 +23,7 @@ public class TripViewHolder extends RecyclerView.ViewHolder {
     @BindView(R.id.cbShare) AppCompatCheckBox cbShare;
     @BindView(R.id.pbImageLoading) ProgressBar pbImageLoading;
     @BindView(R.id.rlTrip) RelativeLayout rlTrip;
+    @BindView(R.id.tvLocation) TextView tvLocation;
 
     public TripViewHolder(View itemView) {
         super(itemView);
@@ -46,5 +47,7 @@ public class TripViewHolder extends RecyclerView.ViewHolder {
     }
 
     public RelativeLayout getRelativeLayout(){ return this.rlTrip; }
+
+    public TextView getTripLocation() { return this.tvLocation; }
 }
 

--- a/app/src/main/java/com/codepath/travel/adapters/TripsAdapter.java
+++ b/app/src/main/java/com/codepath/travel/adapters/TripsAdapter.java
@@ -78,6 +78,11 @@ public class TripsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         tvTripTitle.setText(trip.getTitle());
         TextView tvTripDates = viewHolder.getTripDates();
         tvTripDates.setText(DateUtils.formatDateRange(mContext, trip.getStartDate(), trip.getEndDate()));
+        TextView tvLocation = viewHolder.getTripLocation();
+        if(trip.getDestinationPlaceName() != null) {
+            tvLocation.setText(trip.getDestinationPlaceName());
+        }
+
 
         // sharing checkbox (currently for my trips tab only)
         CheckBox cbShare = viewHolder.cbShare;

--- a/app/src/main/java/com/codepath/travel/models/parse/ParseModelConstants.java
+++ b/app/src/main/java/com/codepath/travel/models/parse/ParseModelConstants.java
@@ -18,6 +18,7 @@ public final class ParseModelConstants {
     public static final String TRIP_CLASS_NAME = "Trip";
     public static final String TITLE_KEY = "title";
     public static final String DESTINATION_PLACE_ID_KEY = "destinationPlaceId";
+    public static final String DESTINATION_PLACE_NAME_KEY = "destinationPlaceName";
     public static final String START_DATE_KEY = "startDate";
     public static final String END_DATE_KEY = "endDate";
 

--- a/app/src/main/java/com/codepath/travel/models/parse/Trip.java
+++ b/app/src/main/java/com/codepath/travel/models/parse/Trip.java
@@ -29,11 +29,11 @@ public class Trip extends ParseObject {
     }
 
     // for use until we use API places
-    public Trip(ParseUser user, String title) {
+    public Trip(ParseUser user, String destinationName) {
         super();
         setDefaultACL(user);
         setUser(user);
-        setTitle(title);
+        setDestinationPlaceName(destinationName);
     }
 
     public Trip(ParseUser user, String title, Place destination) {
@@ -66,6 +66,14 @@ public class Trip extends ParseObject {
 
     public void setDestinationPlaceId(String destinationPlaceId) {
         put(DESTINATION_PLACE_ID_KEY, destinationPlaceId);
+    }
+
+    public String getDestinationPlaceName() {
+        return getString(DESTINATION_PLACE_NAME_KEY);
+    }
+
+    public void setDestinationPlaceName(String destinationPlaceName) {
+        put(DESTINATION_PLACE_NAME_KEY, destinationPlaceName);
     }
 
     public String getCoverPicUrl() {

--- a/app/src/main/res/drawable/ic_date.xml
+++ b/app/src/main/res/drawable/ic_date.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8zM12.5,7L11,7v6l5.25,3.15 0.75,-1.23 -4.5,-2.67z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_location.xml
+++ b/app/src/main/res/drawable/ic_location.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,2C8.13,2 5,5.13 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.87 -3.13,-7 -7,-7zM12,11.5c-1.38,0 -2.5,-1.12 -2.5,-2.5s1.12,-2.5 2.5,-2.5 2.5,1.12 2.5,2.5 -1.12,2.5 -2.5,2.5z"/>
+</vector>

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -4,17 +4,14 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
 
     <!-- Main Content (DrawerLayout's first child) -->
-    <!-- Setting fitSystemWindows=true adds top padding so that content is displayed below the system status bar.
-        Looks slightly weird when scrolling since the toolbar is supposed to disappear but it stops and
-        is still visible under the system bar -->
     <android.support.design.widget.CoordinatorLayout
         android:id="@+id/main_content"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:fitsSystemWindows="true"
         tools:context="com.codepath.travel.activities.HomeActivity">
 
         <!-- AppBarLayout must be first child of CoordinatorLayout -->
@@ -31,7 +28,7 @@
                 android:minHeight="?attr/actionBarSize"
                 app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
                 android:background="?attr/colorPrimaryDark"
-                app:layout_scrollFlags="scroll|enterAlways">
+                app:layout_scrollFlags="scroll|enterAlways|snap">
 
                 <!-- Google Places search auto complete fragment -->
                 <fragment

--- a/app/src/main/res/layout/item_trip.xml
+++ b/app/src/main/res/layout/item_trip.xml
@@ -1,62 +1,97 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
+
+<android.support.v7.widget.CardView
+    xmlns:card_view="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:backgroundTint="@color/colorTransparentBackground"
-    android:backgroundTintMode="src_over">
-
-    <ImageView
-        android:id="@+id/ivProfilePhoto"
-        android:layout_width="@dimen/profile_pic_size"
-        android:layout_height="@dimen/profile_pic_size"
-        android:layout_marginRight="@dimen/margin"
-        android:layout_marginEnd="@dimen/margin"
-        android:src="@drawable/com_facebook_profile_picture_blank_portrait" />
-
-    <TextView
-        android:id="@+id/tvTripTitle"
-        tools:text="Trip 1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_toRightOf="@+id/ivProfilePhoto"
-        android:layout_toEndOf="@+id/ivProfilePhoto"
-        android:layout_marginBottom="@dimen/margin"
-        android:textAppearance="@style/TextAppearance.AppCompat.Title" />
-
-    <TextView
-        android:id="@+id/tvTripDates"
-        tools:text="MMM dd, yyyy - MMM dd, yyyy"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/tvTripTitle"
-        android:layout_toRightOf="@+id/ivProfilePhoto"
-        android:layout_toEndOf="@+id/ivProfilePhoto"
-        android:textAppearance="@style/TextAppearance.AppCompat.Small" />
-
+    android:clickable="true"
+    android:foreground="?android:attr/selectableItemBackground"
+    card_view:cardBackgroundColor="@color/white"
+    card_view:cardCornerRadius="2dp"
+    card_view:cardElevation="2dp"
+    card_view:contentPadding="5dp"
+    card_view:cardUseCompatPadding="true">
     <RelativeLayout
-        android:id="@+id/rlTrip"
-        android:layout_marginTop="4dp"
-        android:layout_below="@id/tvTripDates"
         android:layout_width="match_parent"
-        android:layout_height="192dp">
+        android:layout_height="wrap_content"
+        android:backgroundTint="@color/colorTransparentBackground"
+        android:backgroundTintMode="src_over">
 
-        <ProgressBar
-            android:id="@+id/pbImageLoading"
-            android:layout_centerHorizontal="true"
-            android:layout_centerVertical="true"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
+        <RelativeLayout
+            android:id="@+id/rlTrip"
+            android:layout_width="match_parent"
+            android:layout_height="192dp">
+
+            <ProgressBar
+                android:id="@+id/pbImageLoading"
+                android:layout_centerHorizontal="true"
+                android:layout_centerVertical="true"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
+        </RelativeLayout>
 
         <android.support.v7.widget.AppCompatCheckBox
             android:id="@+id/cbShare"
             android:button="@drawable/checkbox_share"
             android:layout_width="@dimen/icon_size"
             android:layout_height="@dimen/icon_size"
+            android:layout_alignTop="@id/rlTrip"
             android:layout_margin="10dp"
-            android:layout_alignParentBottom="true"
+            android:layout_alignParentTop="true"
             android:layout_alignParentRight="true"/>
+
+
+        <TextView
+            android:id="@+id/tvTripTitle"
+            tools:text="Trip 1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/rlTrip"
+            android:layout_marginTop="@dimen/margin"
+            android:textStyle="bold"
+            android:textSize="16sp"
+            android:textColor="@color/darkGray"/>
+
+        <TextView
+            android:id="@+id/tvTripDates"
+            tools:text="MMM dd, yyyy - MMM dd, yyyy"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/tvTripTitle"
+            android:layout_marginTop="2dp"
+            android:drawableLeft="@drawable/ic_date"
+            android:drawableTint="@color/colorTransparentBackground"
+            android:drawablePadding="2dp"
+            android:textSize="12sp"
+            android:textColor="@color/colorTransparentBackground"/>
+
+        <ImageView
+            android:id="@+id/ivProfilePhoto"
+            android:layout_width="@dimen/profile_pic_size"
+            android:layout_height="@dimen/profile_pic_size"
+            android:layout_alignBottom="@id/tvTripTitle"
+            android:layout_alignParentRight="true"
+            android:layout_alignParentEnd="true"
+            android:layout_marginRight="@dimen/margin"
+            android:layout_marginEnd="@dimen/margin"
+            android:src="@drawable/com_facebook_profile_picture_blank_portrait" />
+
+        <TextView
+            android:id="@+id/tvLocation"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:drawableLeft="@drawable/ic_location"
+            android:drawableTint="@color/colorTransparentBackground"
+            android:drawablePadding="2dp"
+            tools:text="San Francisco"
+            android:textSize="12sp"
+            android:textColor="@color/colorTransparentBackground"
+            android:layout_alignBaseline="@+id/tvTripDates"
+            android:layout_alignParentBottom="true"
+            android:layout_alignBottom="@+id/tvTripDates"
+            android:layout_marginLeft="170dp" />
     </RelativeLayout>
-</RelativeLayout>
+    </android.support.v7.widget.CardView>

--- a/app/src/main/res/layout/layout_tabs.xml
+++ b/app/src/main/res/layout/layout_tabs.xml
@@ -16,5 +16,5 @@
         android:id="@+id/tabViewPager"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"/>
+        android:layout_weight="1" />
 </LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,9 +8,9 @@
     <color name="colorTransparentBackground">#60000000</color>
     <color name="green">#008000</color>
     <color name="tango">#F07621</color>
-    <color name="dodger_blue">#1DA1F2</color>
     <color name="white">@android:color/white</color>
     <color name="lightGray">#CECECE</color>
     <color name="heart">#CC817C</color>
     <color name="red">#BC3F3C</color>
+    <color name="darkGray">#4c4c4c</color>
 </resources>


### PR DESCRIPTION
- Trips are shown in card view as in Google Trips app.
- Included location attribute in Trip class to store the location of trip. Previously title was used for that but since title be customized by user there was no specific indication of the destination hence added location. So, you would see blank location for the trips which were created before this update. New trips will have their location shown in the feed.
- Made few changes to the alignment of trip item contents.
- Fixed the scrolling behavior of coordinator layout to completely hide toolbar on scroll in trip feed