### PR TITLE
More story activity styling

### DIFF
--- a/app/src/main/java/com/codepath/travel/activities/CreateStoryActivity.java
+++ b/app/src/main/java/com/codepath/travel/activities/CreateStoryActivity.java
@@ -56,6 +56,7 @@ public class CreateStoryActivity extends BaseActivity implements OnStartDragList
     private static final String TAG = CreateStoryActivity.class.getSimpleName();
 
     // strings
+    @BindString(R.string.toolbar_title_create_story) String toolbarTitle;
     @BindString(R.string.default_trip_title) String tripTitleFormat;
     @BindString(R.string.hint_trip_dates) String hintTripDates;
     @BindString(R.string.error_trip_dates) String errorTripDates;
@@ -89,10 +90,11 @@ public class CreateStoryActivity extends BaseActivity implements OnStartDragList
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_create_story);
         initializeCommonViews();
+        toolbar.setTitle(toolbarTitle);
 
         mDestination = getIntent().getStringExtra(Constants.PLACE_NAME_ARG);
         mDestinationPhotoRef = getIntent().getStringExtra(Constants.PLACE_PHOTO_REF_ARG);
-        //Get list of selected places from suggestions screen
+        // Get list of selected places from suggestions screen
         mSelectedSuggestionPlaces = Parcels.unwrap(getIntent().getParcelableExtra(
                 Constants.SUGGESTION_PLACES_LIST_ARG));
 
@@ -311,6 +313,9 @@ public class CreateStoryActivity extends BaseActivity implements OnStartDragList
         // as you specify a parent activity in AndroidManifest.xml.
         //int id = item.getItemId();
         switch (item.getItemId()) {
+            case android.R.id.home:
+                onBackPressed();
+                return true;
             default:
                 return super.onOptionsItemSelected(item);
         }
@@ -320,6 +325,7 @@ public class CreateStoryActivity extends BaseActivity implements OnStartDragList
     public void onBackPressed() {
         mNewTrip.deleteInBackground();
         super.onBackPressed();
+        finish();
     }
 
 }

--- a/app/src/main/java/com/codepath/travel/activities/HomeActivity.java
+++ b/app/src/main/java/com/codepath/travel/activities/HomeActivity.java
@@ -237,7 +237,7 @@ public class HomeActivity extends AppCompatActivity implements TripClickListener
             etAutocomplete.setText("");
         } else if (resultCode == RESULT_OK && requestCode == STORY_REQUEST) {
             // trip deleted
-            tabViewPager.getAdapter().notifyDataSetChanged();
+            mHomePagerAdapter.notifyDataSetChanged();
         }
     }
 

--- a/app/src/main/java/com/codepath/travel/activities/StoryActivity.java
+++ b/app/src/main/java/com/codepath/travel/activities/StoryActivity.java
@@ -29,7 +29,6 @@ import android.widget.TextView;
 import com.codepath.travel.Constants;
 import com.codepath.travel.R;
 import com.codepath.travel.adapters.SwipeStoryPlaceAdapter;
-import com.codepath.travel.decoration.DividerItemDecoration;
 import com.codepath.travel.fragments.dialog.ConfirmDeleteTripDialogFragment;
 import com.codepath.travel.fragments.dialog.DateRangePickerFragment;
 import com.codepath.travel.fragments.dialog.EditMediaDialogFragment;

--- a/app/src/main/java/com/codepath/travel/adapters/SwipeStoryPlaceAdapter.java
+++ b/app/src/main/java/com/codepath/travel/adapters/SwipeStoryPlaceAdapter.java
@@ -3,12 +3,14 @@ package com.codepath.travel.adapters;
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
 
+import static com.codepath.travel.R.id.swipe;
 import static com.codepath.travel.helper.DateUtils.FUTURE;
 import static com.codepath.travel.helper.DateUtils.PAST;
 
 import android.content.Context;
 import android.graphics.Color;
 import android.support.v7.widget.AppCompatCheckBox;
+import android.support.v7.widget.CardView;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
@@ -17,7 +19,6 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
-import android.widget.LinearLayout;
 import android.widget.RatingBar;
 import android.widget.TextView;
 
@@ -125,10 +126,10 @@ public class SwipeStoryPlaceAdapter extends RecyclerSwipeAdapter<SwipeStoryPlace
         @BindView(R.id.rvMediaHolder) RecyclerView rvMediaItems;
 
         // swipe views
-        @BindView(R.id.swipe) SwipeLayout swipeLayout;
-        @BindView(R.id.bottomLeft) LinearLayout leftMenu;
+        @BindView(swipe) SwipeLayout swipeLayout;
+        @BindView(R.id.bottomLeft) CardView leftMenu;
         @BindView(R.id.ivDelete) ImageView ivDelete;
-        @BindView(R.id.bottomRight) LinearLayout rightMenu;
+        @BindView(R.id.bottomRight) CardView rightMenu;
         @BindView(R.id.ivInfo) ImageView ivInfo;
 //        @BindView(R.id.ivEdit) ImageView ivEdit;
         @BindView(R.id.ivNote) ImageView ivNote;
@@ -158,7 +159,8 @@ public class SwipeStoryPlaceAdapter extends RecyclerSwipeAdapter<SwipeStoryPlace
         public void setupSwipe(boolean enabled) {
             if (enabled) {
                 swipeLayout.setSwipeEnabled(true);
-                swipeLayout.setShowMode(SwipeLayout.ShowMode.PullOut);
+                swipeLayout.setShowMode(SwipeLayout.ShowMode.LayDown);
+                swipeLayout.setClickToClose(true);
                 setupListeners();
             } else {
                 swipeLayout.setSwipeEnabled(false);
@@ -202,6 +204,45 @@ public class SwipeStoryPlaceAdapter extends RecyclerSwipeAdapter<SwipeStoryPlace
             ivNote.setOnClickListener(v -> listener.noteOnClick(getRealPosition(mStoryPlace)));
             ivCamera.setOnClickListener(v -> listener.cameraOnClick(getRealPosition(mStoryPlace)));
             ivPhotos.setOnClickListener(v -> listener.galleryOnClick(getRealPosition(mStoryPlace)));
+
+            // click listener on surface view to swipe right on tap
+            swipeLayout.getSurfaceView().setOnClickListener(v -> {
+                for (SwipeLayout layout : getOpenLayouts()) {
+                    layout.close(true);
+                }
+                swipeLayout.open(true, SwipeLayout.DragEdge.Right);
+            });
+
+            swipeLayout.addSwipeListener(new SwipeLayout.SwipeListener() {
+                @Override
+                public void onStartOpen(SwipeLayout layout) {
+                }
+
+                @Override
+                public void onOpen(SwipeLayout layout) {
+
+                }
+
+                @Override
+                public void onStartClose(SwipeLayout layout) {
+
+                }
+
+                @Override
+                public void onClose(SwipeLayout layout) {
+
+                }
+
+                @Override
+                public void onUpdate(SwipeLayout layout, int leftOffset, int topOffset) {
+
+                }
+
+                @Override
+                public void onHandRelease(SwipeLayout layout, float xvel, float yvel) {
+
+                }
+            });
         }
 
         private void setupCheckinCheckbox(StoryPlace storyPlace) {

--- a/app/src/main/java/com/codepath/travel/fragments/dialog/DatePickerFragment.java
+++ b/app/src/main/java/com/codepath/travel/fragments/dialog/DatePickerFragment.java
@@ -10,6 +10,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.Window;
 import android.widget.Button;
 import android.widget.CalendarView;
 import android.widget.TextView;
@@ -66,6 +67,7 @@ public class DatePickerFragment extends DialogFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup parent, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_date_picker, parent, false);
         unbinder = ButterKnife.bind(this, view);
+        getDialog().getWindow().requestFeature(Window.FEATURE_NO_TITLE);
 
         Bundle args = getArguments();
         long dateMillis = args.getLong(DATE_KEY, -1);

--- a/app/src/main/java/com/codepath/travel/fragments/dialog/DateRangePickerFragment.java
+++ b/app/src/main/java/com/codepath/travel/fragments/dialog/DateRangePickerFragment.java
@@ -10,6 +10,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.Window;
 import android.widget.Button;
 import android.widget.CalendarView;
 import android.widget.TextView;
@@ -61,6 +62,7 @@ public class DateRangePickerFragment extends DialogFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup parent, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_date_range_picker, parent, false);
         unbinder = ButterKnife.bind(this, view);
+        getDialog().getWindow().requestFeature(Window.FEATURE_NO_TITLE);
 
         Bundle args = getArguments();
         long startDateMillis = args.getLong(START_DATE_KEY, -1);

--- a/app/src/main/java/com/codepath/travel/net/GoogleAsyncHttpClient.java
+++ b/app/src/main/java/com/codepath/travel/net/GoogleAsyncHttpClient.java
@@ -17,7 +17,9 @@ public class GoogleAsyncHttpClient {
     private static String NEARBY_SEARCH_URL = "https://maps.googleapis.com/maps/api/place/nearbysearch/json?";
     private static String PLACE_PHOTO_URL = "https://maps.googleapis.com/maps/api/place/photo?maxwidth=400";
     public static String PLACE_DETAILS_URL = "https://maps.googleapis.com/maps/api/place/details/json?";
-    public static String GOOGLE_PLACES_SEARCH_API_KEY = "AIzaSyCo5UwvCcWOxwQ1N7vq1G0mfZiab8BGRp4";
+//    public static String GOOGLE_PLACES_SEARCH_API_KEY = "AIzaSyCo5UwvCcWOxwQ1N7vq1G0mfZiab8BGRp4";
+//    public static String GOOGLE_PLACES_SEARCH_API_KEY = "AIzaSyBu7ILXPyx6eFeI70xfYAzp-k2xksqhzfI";
+    public static String GOOGLE_PLACES_SEARCH_API_KEY = "AIzaSyDkD4R2rlb7BRRwDOm3E1G4iRGGRbtBbe8"; // huyen's 2nd key
 
     public static AsyncHttpClient getInstance() {
         return client;

--- a/app/src/main/res/drawable/checkin_forgot_default.xml
+++ b/app/src/main/res/drawable/checkin_forgot_default.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="24.0">
     <path
         android:pathData="M19,1L5,1c-1.1,0 -1.99,0.9 -1.99,2L3,15.93c0,0.69 0.35,1.3 0.88,1.66L12,23l8.11,-5.41c0.53,-0.36 0.88,-0.97 0.88,-1.66L21,3c0,-1.1 -0.9,-2 -2,-2zM10,16l-5,-5 1.41,-1.41L10,13.17l7.59,-7.59L19,7l-9,9z"
-        android:fillColor="@color/tango"/>
+        android:fillColor="@color/colorPrimaryLight"/>
 </vector>

--- a/app/src/main/res/layout/content_story.xml
+++ b/app/src/main/res/layout/content_story.xml
@@ -14,6 +14,7 @@
         android:text="@string/hint_trip_dates"
         android:drawableStart="@drawable/ic_calendar"
         android:drawableTint="@color/colorTransparentBackground"
+        android:textAppearance="@style/textMedium"
         style="@style/textViewWithDrawable"/>
 
     <android.support.v7.widget.AppCompatCheckBox
@@ -37,7 +38,7 @@
         android:layout_alignBottom="@+id/cbShare"
         android:gravity="center_vertical"
         android:text="@string/share_label"
-        android:textAppearance="@style/subheaderText"/>
+        android:textAppearance="@style/textMedium"/>
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/rvStoryPlaces"

--- a/app/src/main/res/layout/fragment_date_picker.xml
+++ b/app/src/main/res/layout/fragment_date_picker.xml
@@ -3,14 +3,15 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="@dimen/margin">
+    android:padding="@dimen/activity_horizontal_margin">
 
     <TextView
         android:id="@+id/tvDateLabel"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/checkin_date"
-        android:layout_marginBottom="@dimen/margin"/>
+        android:layout_marginBottom="@dimen/space"
+        android:textAppearance="@style/subheaderText"/>
 
     <TextView
         android:id="@+id/tvDate"
@@ -18,7 +19,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         tools:text="Nov 23, 2016"
-        android:layout_marginBottom="@dimen/margin"/>
+        android:layout_marginBottom="@dimen/space"
+        android:textAppearance="@style/body1Text"/>
 
     <View
         android:id="@+id/viewSeparator"
@@ -27,28 +29,36 @@
         android:layout_below="@+id/tvDate"
         android:background="@color/lightGray" />
 
-    <CalendarView
-        android:id="@+id/calendarView"
+    <ScrollView
+        android:id="@+id/calendarHolder"
         android:layout_below="@+id/viewSeparator"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/space">
+        <CalendarView
+            android:id="@+id/calendarView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </ScrollView>
 
     <Button
         android:id="@+id/btnSave"
-        android:text="Save"
+        android:text="@string/save"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/calendarView"
+        android:layout_below="@id/calendarHolder"
         android:layout_alignParentRight="true"
-        android:layout_alignParentEnd="true" />
+        android:layout_alignParentEnd="true"
+        style="@style/Widget.AppCompat.Button.ButtonBar.AlertDialog" />
 
     <Button
         android:id="@+id/btnCancel"
-        android:text="Cancel"
+        android:text="@string/cancel"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/calendarView"
-        android:layout_toLeftOf="@+id/btnSave"
-        android:layout_toStartOf="@+id/btnSave" />
+        android:layout_below="@id/calendarHolder"
+        android:layout_toLeftOf="@id/btnSave"
+        android:layout_toStartOf="@id/btnSave"
+        style="@style/Widget.AppCompat.Button.ButtonBar.AlertDialog" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_date_picker.xml
+++ b/app/src/main/res/layout/fragment_date_picker.xml
@@ -11,7 +11,7 @@
         android:layout_height="wrap_content"
         android:text="@string/checkin_date"
         android:layout_marginBottom="@dimen/space"
-        android:textAppearance="@style/subheaderText"/>
+        android:textAppearance="@style/textLarge"/>
 
     <TextView
         android:id="@+id/tvDate"
@@ -20,14 +20,14 @@
         android:layout_height="wrap_content"
         tools:text="Nov 23, 2016"
         android:layout_marginBottom="@dimen/space"
-        android:textAppearance="@style/body1Text"/>
+        android:textAppearance="@style/textMedium"/>
 
     <View
         android:id="@+id/viewSeparator"
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:layout_below="@+id/tvDate"
-        android:background="@color/lightGray" />
+        android:background="@color/divider" />
 
     <ScrollView
         android:id="@+id/calendarHolder"

--- a/app/src/main/res/layout/fragment_date_range_picker.xml
+++ b/app/src/main/res/layout/fragment_date_range_picker.xml
@@ -16,7 +16,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/space"
-            android:textAppearance="@style/subheaderText"
+            android:textAppearance="@style/textLarge"
             android:text="@string/start_date" />
 
         <TextView
@@ -24,7 +24,7 @@
             android:layout_below="@id/tvStartLabel"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textAppearance="@style/body1Text"
+            android:textAppearance="@style/textMedium"
             tools:text="Nov 11, 2016" />
 
         <View
@@ -43,7 +43,7 @@
             android:layout_toEndOf="@+id/verticalLine"
             android:layout_marginLeft="@dimen/margin"
             android:layout_marginBottom="@dimen/space"
-            android:textAppearance="@style/subheaderText"
+            android:textAppearance="@style/textLarge"
             android:text="@string/end_date" />
 
         <TextView
@@ -54,7 +54,7 @@
             android:layout_toRightOf="@+id/verticalLine"
             android:layout_toEndOf="@+id/verticalLine"
             android:layout_marginLeft="@dimen/margin"
-            android:textAppearance="@style/body1Text"
+            android:textAppearance="@style/textMedium"
             tools:text="Dec 11, 2016" />
     </RelativeLayout>
 
@@ -63,7 +63,7 @@
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:layout_below="@+id/rlDatesContainer"
-        android:background="@color/lightGray" />
+        android:background="@color/divider" />
 
     <LinearLayout
         android:id="@+id/llDurationRow"
@@ -78,7 +78,7 @@
             android:id="@+id/tvDurationLabel"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textAppearance="@style/body1Text"
+            android:textAppearance="@style/textMedium"
             android:text="@string/duration_label"/>
 
         <TextView
@@ -88,7 +88,7 @@
             tools:text="1 month"
             android:layout_marginLeft="@dimen/textDrawablePadding"
             android:layout_marginStart="@dimen/textDrawablePadding"
-            android:textAppearance="@style/body1Text"/>
+            android:textAppearance="@style/textMedium"/>
 
     </LinearLayout>
 
@@ -97,7 +97,7 @@
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:layout_below="@+id/llDurationRow"
-        android:background="@color/lightGray" />
+        android:background="@color/divider" />
 
     <ScrollView
         android:id="@+id/calendarHolder"

--- a/app/src/main/res/layout/fragment_date_range_picker.xml
+++ b/app/src/main/res/layout/fragment_date_range_picker.xml
@@ -2,31 +2,35 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:padding="@dimen/activity_horizontal_margin">
 
     <RelativeLayout
         android:id="@+id/rlDatesContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="@dimen/margin" >
+        android:layout_marginBottom="@dimen/space" >
 
         <TextView
+            android:id="@+id/tvStartLabel"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:id="@+id/tvStartLabel"
+            android:layout_marginBottom="@dimen/space"
+            android:textAppearance="@style/subheaderText"
             android:text="@string/start_date" />
 
         <TextView
-            android:layout_below="@+id/tvStartLabel"
+            android:id="@+id/tvStartDate"
+            android:layout_below="@id/tvStartLabel"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:id="@+id/tvStartDate"
+            android:textAppearance="@style/body1Text"
             tools:text="Nov 11, 2016" />
 
         <View
             android:id="@+id/verticalLine"
             android:layout_width="1dp"
-            android:layout_height="30dp"
+            android:layout_height="40dp"
             android:layout_centerVertical="false"
             android:background="@color/lightGray"
             android:layout_centerInParent="true" />
@@ -38,6 +42,8 @@
             android:layout_toRightOf="@+id/verticalLine"
             android:layout_toEndOf="@+id/verticalLine"
             android:layout_marginLeft="@dimen/margin"
+            android:layout_marginBottom="@dimen/space"
+            android:textAppearance="@style/subheaderText"
             android:text="@string/end_date" />
 
         <TextView
@@ -48,6 +54,7 @@
             android:layout_toRightOf="@+id/verticalLine"
             android:layout_toEndOf="@+id/verticalLine"
             android:layout_marginLeft="@dimen/margin"
+            android:textAppearance="@style/body1Text"
             tools:text="Dec 11, 2016" />
     </RelativeLayout>
 
@@ -64,21 +71,24 @@
         android:layout_height="wrap_content"
         android:layout_below="@+id/viewSeparator1"
         android:orientation="horizontal"
-        android:padding="@dimen/margin">
+        android:layout_marginTop="@dimen/space"
+        android:layout_marginBottom="@dimen/space">
 
         <TextView
             android:id="@+id/tvDurationLabel"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Duration:"/>
+            android:textAppearance="@style/body1Text"
+            android:text="@string/duration_label"/>
 
         <TextView
             android:id="@+id/tvDuration"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             tools:text="1 month"
-            android:layout_marginLeft="@dimen/margin"
-            android:layout_marginStart="@dimen/margin"/>
+            android:layout_marginLeft="@dimen/textDrawablePadding"
+            android:layout_marginStart="@dimen/textDrawablePadding"
+            android:textAppearance="@style/body1Text"/>
 
     </LinearLayout>
 
@@ -89,29 +99,37 @@
         android:layout_below="@+id/llDurationRow"
         android:background="@color/lightGray" />
 
-    <CalendarView
-        android:id="@+id/calendarView"
-        android:layout_below="@+id/viewSeparator2"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+    <ScrollView
+        android:id="@+id/calendarHolder"
+        android:layout_below="@id/viewSeparator2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/space">
+        <CalendarView
+            android:id="@+id/calendarView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </ScrollView>
 
     <Button
         android:id="@+id/btnSave"
-        android:text="Save"
+        android:text="@string/save"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/calendarView"
+        android:layout_below="@id/calendarHolder"
         android:layout_alignParentRight="true"
         android:layout_alignParentEnd="true"
-        android:enabled="false"/>
+        android:enabled="false"
+        style="@style/Widget.AppCompat.Button.ButtonBar.AlertDialog" />
 
     <Button
         android:id="@+id/btnCancel"
-        android:text="Cancel"
+        android:text="@string/cancel"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/calendarView"
-        android:layout_toLeftOf="@+id/btnSave"
-        android:layout_toStartOf="@+id/btnSave" />
+        android:layout_below="@id/calendarHolder"
+        android:layout_toLeftOf="@id/btnSave"
+        android:layout_toStartOf="@id/btnSave"
+        style="@style/Widget.AppCompat.Button.ButtonBar.AlertDialog" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/item_media.xml
+++ b/app/src/main/res/layout/item_media.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_margin="8dp"
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_margin="@dimen/space"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+
     <ImageView
         android:id="@+id/ivPlacePhoto"
-        xmlns:tools="http://schemas.android.com/tools"
         tools:src="@android:drawable/ic_menu_camera"
-        android:scaleType="fitXY"
-        android:layout_width="120dp"
-        android:layout_height="120dp"/>
+        android:scaleType="centerCrop"
+        android:layout_width="@dimen/media_size"
+        android:layout_height="@dimen/media_size"/>
 </LinearLayout>

--- a/app/src/main/res/layout/item_media_text.xml
+++ b/app/src/main/res/layout/item_media_text.xml
@@ -3,15 +3,16 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
-    android:layout_margin="8dp"
+    android:layout_margin="@dimen/space"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content">
 
     <TextView
         android:id="@+id/tvNoteMedia"
-        tools:text="This is a note, a really long note, really really really really really long note, it goes on and on and on and on and on and on and on and on and on and on and on, until the end!"
-        android:layout_width="120dp"
-        android:layout_height="wrap_content"
-        android:maxLines="4"
-        android:ellipsize="end"/>
+        tools:text="This is a note, a really long note, really really really really really long note, it goes on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on and on, until the end!"
+        android:layout_width="@dimen/media_size"
+        android:layout_height="@dimen/media_size"
+        android:maxLines="8"
+        android:ellipsize="end"
+        android:textAppearance="@style/textSmall"/>
 </LinearLayout>

--- a/app/src/main/res/layout/item_storyplace.xml
+++ b/app/src/main/res/layout/item_storyplace.xml
@@ -4,6 +4,7 @@
     xmlns:swipe="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:card_view="http://schemas.android.com/apk/res-auto"
     android:id="@+id/swipe"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -11,65 +12,77 @@
     swipe:rightEdgeSwipeOffset="0dp">
 
     <!-- Swipe Menu: Left side -->
-    <LinearLayout
+    <android.support.v7.widget.CardView
         android:id="@+id/bottomLeft"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
-        android:orientation="horizontal"
-        android:layout_gravity="start"
-        android:gravity="center"
-        android:padding="@dimen/activity_horizontal_margin"
-        android:background="@color/red">
+        style="@style/cardViewBase"
+        card_view:cardElevation="0dp"
+        card_view:cardBackgroundColor="@color/red"
+        android:layout_gravity="start">
 
-        <ImageView
-            android:id="@+id/ivDelete"
-            app:srcCompat="@drawable/ic_delete"
-            android:layout_width="@dimen/icon_size"
-            android:layout_height="@dimen/icon_size"/>
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:orientation="horizontal"
+            android:gravity="center"
+            android:padding="@dimen/activity_horizontal_margin">
 
-    </LinearLayout>
+            <ImageView
+                android:id="@+id/ivDelete"
+                app:srcCompat="@drawable/ic_delete"
+                android:layout_width="@dimen/icon_size"
+                android:layout_height="@dimen/icon_size"/>
+        </LinearLayout>
+    </android.support.v7.widget.CardView>
 
     <!-- Swipe Menu: Right side -->
-    <LinearLayout
+    <android.support.v7.widget.CardView
         android:id="@+id/bottomRight"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
-        android:orientation="horizontal"
+        style="@style/cardViewBase"
+        card_view:cardElevation="0dp"
         android:layout_gravity="end"
-        android:gravity="center"
-        android:padding="@dimen/activity_horizontal_margin"
-        android:background="@color/green">
+        card_view:cardBackgroundColor="@color/green">
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:orientation="horizontal"
+            android:gravity="center"
+            android:padding="@dimen/activity_horizontal_margin">
 
-        <ImageView
-            android:id="@+id/ivInfo"
-            app:srcCompat="@drawable/ic_info"
-            android:layout_width="@dimen/icon_size"
-            android:layout_height="@dimen/icon_size"
-            android:layout_marginRight="@dimen/margin"
-            android:layout_marginEnd="@dimen/margin"/>
+            <ImageView
+                android:id="@+id/ivInfo"
+                app:srcCompat="@drawable/ic_info"
+                android:layout_width="@dimen/icon_size"
+                android:layout_height="@dimen/icon_size"
+                android:layout_marginRight="@dimen/margin"
+                android:layout_marginEnd="@dimen/margin"/>
 
-        <ImageView
-            android:id="@+id/ivNote"
-            app:srcCompat="@drawable/ic_add_note"
-            android:layout_width="@dimen/icon_size"
-            android:layout_height="@dimen/icon_size"
-            android:layout_marginRight="@dimen/margin"
-            android:layout_marginEnd="@dimen/margin"/>
+            <ImageView
+                android:id="@+id/ivNote"
+                app:srcCompat="@drawable/ic_add_note"
+                android:layout_width="@dimen/icon_size"
+                android:layout_height="@dimen/icon_size"
+                android:layout_marginRight="@dimen/margin"
+                android:layout_marginEnd="@dimen/margin"/>
 
-        <ImageView
-            android:id="@+id/ivCamera"
-            app:srcCompat="@drawable/ic_add_photo"
-            android:layout_width="@dimen/icon_size"
-            android:layout_height="@dimen/icon_size"
-            android:layout_marginRight="@dimen/margin"
-            android:layout_marginEnd="@dimen/margin"/>
+            <ImageView
+                android:id="@+id/ivCamera"
+                app:srcCompat="@drawable/ic_add_photo"
+                android:layout_width="@dimen/icon_size"
+                android:layout_height="@dimen/icon_size"
+                android:layout_marginRight="@dimen/margin"
+                android:layout_marginEnd="@dimen/margin"/>
 
-        <ImageView
-            android:id="@+id/ivPhotos"
-            app:srcCompat="@drawable/ic_photo_library"
-            android:layout_width="@dimen/icon_size"
-            android:layout_height="@dimen/icon_size"/>
-    </LinearLayout>
+            <ImageView
+                android:id="@+id/ivPhotos"
+                app:srcCompat="@drawable/ic_photo_library"
+                android:layout_width="@dimen/icon_size"
+                android:layout_height="@dimen/icon_size"/>
+        </LinearLayout>
+    </android.support.v7.widget.CardView>
 
     <!-- Top View (recycler view item) -->
     <!-- Too much nesting? -->
@@ -86,8 +99,7 @@
             <RelativeLayout
                 android:id="@+id/llHeader"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/margin_s">
+                android:layout_height="wrap_content">
 
                 <ImageView
                     android:id="@+id/ivPlacePhoto"
@@ -144,6 +156,7 @@
                 android:id="@+id/rvMediaHolder"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/media_size"
+                android:layout_marginTop="@dimen/space"
                 android:layout_marginBottom="@dimen/margin_s"/>
         </LinearLayout>
     </android.support.v7.widget.CardView>

--- a/app/src/main/res/layout/item_storyplace.xml
+++ b/app/src/main/res/layout/item_storyplace.xml
@@ -127,7 +127,8 @@
                     android:layout_marginEnd="@dimen/margin_s"
                     android:layout_marginBottom="@dimen/margin"
                     tools:text="@string/forgot_checkin"
-                    android:textAppearance="@style/body1Text"/>
+                    android:textAppearance="@style/textMedium"
+                    android:textColor="@color/tertiary_text"/>
 
                 <RatingBar
                     android:id="@+id/rbUserRating"
@@ -149,7 +150,7 @@
                     android:layout_toStartOf="@id/tvCheckin"
                     android:layout_marginStart="@dimen/activity_horizontal_margin"
                     tools:text="Place Name Name Name Name Name Very Long Name"
-                    android:textAppearance="@style/body2Text"/>
+                    android:textAppearance="@style/textMediumBold"/>
             </RelativeLayout>
 
             <android.support.v7.widget.RecyclerView

--- a/app/src/main/res/layout/item_trip.xml
+++ b/app/src/main/res/layout/item_trip.xml
@@ -44,7 +44,7 @@
             android:layout_height="wrap_content"
             android:layout_below="@id/rlTrip"
             android:layout_marginTop="@dimen/space"
-            android:textAppearance="@style/titleText"
+            android:textAppearance="@style/textLarge"
             android:textColor="@color/darkGray"/>
 
         <TextView
@@ -55,9 +55,11 @@
             android:layout_below="@+id/tvTripTitle"
             android:layout_marginTop="@dimen/space"
             android:drawableStart="@drawable/ic_date"
-            android:drawableTint="@color/colorTransparentBackground"
-            style="@style/textViewWithDrawable"
-            android:textAppearance="@style/body1Text"/>
+            android:drawableTint="@color/secondary_text"
+            android:drawablePadding="@dimen/textDrawablePadding"
+            android:gravity="center_vertical"
+            android:textSize="12sp"
+            android:textColor="@color/secondary_text" />
 
         <ImageView
             android:id="@+id/ivProfilePhoto"
@@ -74,14 +76,17 @@
             android:id="@+id/tvLocation"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            tools:text="San Francisco"
+            android:layout_marginLeft="170dp"
             android:layout_alignBaseline="@+id/tvTripDates"
             android:layout_alignParentBottom="true"
             android:layout_alignBottom="@+id/tvTripDates"
-            android:layout_marginLeft="170dp"
-            android:drawableStart="@drawable/ic_location"
-            android:drawableTint="@color/colorTransparentBackground"
-            style="@style/textViewWithDrawable"
-            android:textAppearance="@style/body1Text"/>
+            android:drawableLeft="@drawable/ic_location"
+            android:drawableTint="@color/secondary_text"
+            android:drawablePadding="@dimen/textDrawablePadding"
+            android:gravity="center_vertical"
+            android:textSize="12sp"
+            android:textColor="@color/secondary_text"
+            tools:text="San Francisco"/>
+
     </android.support.percent.PercentRelativeLayout>
 </android.support.v7.widget.CardView>

--- a/app/src/main/res/layout/item_trip.xml
+++ b/app/src/main/res/layout/item_trip.xml
@@ -56,7 +56,8 @@
             android:layout_marginTop="@dimen/space"
             android:drawableStart="@drawable/ic_date"
             android:drawableTint="@color/colorTransparentBackground"
-            style="@style/textViewWithDrawable" />
+            style="@style/textViewWithDrawable"
+            android:textAppearance="@style/body1Text"/>
 
         <ImageView
             android:id="@+id/ivProfilePhoto"
@@ -80,6 +81,7 @@
             android:layout_marginLeft="170dp"
             android:drawableStart="@drawable/ic_location"
             android:drawableTint="@color/colorTransparentBackground"
-            style="@style/textViewWithDrawable"/>
+            style="@style/textViewWithDrawable"
+            android:textAppearance="@style/body1Text"/>
     </android.support.percent.PercentRelativeLayout>
 </android.support.v7.widget.CardView>

--- a/app/src/main/res/layout/layout_tabs.xml
+++ b/app/src/main/res/layout/layout_tabs.xml
@@ -10,7 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:tabMode="fixed"
-        style="@style/MyCustomTabLayout"/>
+        style="@style/pagerTabs"/>
 
     <android.support.v4.view.ViewPager
         android:id="@+id/tabViewPager"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,21 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#3F51B5</color>
-    <color name="colorPrimaryDark">#303F9F</color>
-    <color name="colorAccent">#303F9F</color>
-
-    <color name="transparent">#00000000</color>
-    <color name="colorTransparentBackground">#60000000</color>
-    <color name="green">#008000</color>
-    <color name="tango">#F07621</color>
-    <color name="white">@android:color/white</color>
-    <color name="lightGray">#CECECE</color>
-    <color name="heart">#CC817C</color>
-    <color name="red">#BC3F3C</color>
-    <color name="darkGray">#4c4c4c</color>
+    <!-- MAIN COLORS -->
+    <color name="colorPrimary">#FF5722</color>
+    <color name="colorPrimaryDark">#E64A19</color>
+    <color name="colorPrimaryLight">#FFCCBC</color>
+    <color name="colorAccent">#FF9800</color>
 
     <!-- TEXT COLORS -->
+    <color name="primary_text">#212121</color>
+    <color name="secondary_text">#757575</color>
+    <color name="tertiary_text">@color/lightGray</color>
     <color name="subheaderText">#87000000</color>
     <color name="captionText">#54000000</color>
->>>>>>> styles
+
+    <!-- ITEM COLORS -->
+    <color name="icons">#FFFFFF</color>
+    <color name="divider">@color/lightGray</color>
+
+    <!-- OTHER COLORS -->
+    <color name="transparent">#00000000</color>
+    <color name="colorTransparentBackground">#60000000</color>
+    <color name="white">@android:color/white</color>
+    <color name="lightGray">#BDBDBD</color>
+    <color name="darkGray">#4c4c4c</color>
+    <color name="red">#BC3F3C</color>
+    <color name="green">#008000</color>
+    <color name="tango">#F07621</color>
+    <color name="heart">#CC817C</color>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,8 @@
 <resources>
     <!-- APIs and Integrations -->
     <string name="parse_app_id">traveltrails</string>
-    <string name="google_api_key">AIzaSyCOhSebiVixAE8Aq5atvtzWJAhHuZH5l_U</string>
+    <!--<string name="google_api_key">AIzaSyCOhSebiVixAE8Aq5atvtzWJAhHuZH5l_U</string>-->
+    <string name="google_api_key">AIzaSyDkD4R2rlb7BRRwDOm3E1G4iRGGRbtBbe8</string> <!-- huyen's 2nd key -->
     <string name="facebook_app_id">646488778862200</string>
 
     <!-- App related strings -->
@@ -63,6 +64,7 @@
     <string name="hint_trip_dates">Select Trip Dates</string>
     <string name="start_date">Start Date</string>
     <string name="end_date">End Date</string>
+    <string name="duration_label">Duration:</string>
 
     <!-- Sharing -->
     <string name="share_trip">Share Trip</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -83,7 +83,7 @@
         <item name="android:textColor">@color/subheaderText</item>
     </style>
 
-    <!-- Subheading (Roboto Regular, 16sp) -->
+    <!-- Subheader (Roboto Regular, 16sp) -->
     <style name="subheaderText" parent="Base.TextAppearance.AppCompat.Subhead">
         <item name="android:textColor">@color/subheaderText</item>
     </style>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -62,45 +62,26 @@
     </style>
 
 
-    <!-- TAB LAYOUT -->
-    <style name="MyCustomTabLayout" parent="Widget.Design.TabLayout">
-        <item name="tabTextAppearance">@style/MyCustomTextAppearance</item>
-    </style>
-    <!-- overriding textAllCaps so icons render -->
-    <style name="MyCustomTextAppearance" parent="TextAppearance.Design.Tab">
-        <item name="textAllCaps">false</item>
+    <!-- TEXT STYLES -->
+    <!-- Large 16sp (Roboto Regular) -->
+    <style name="textLarge" parent="Base.TextAppearance.AppCompat.Subhead">
+        <item name="android:fontFamily">sans-serif-medium</item>
+        <item name="android:textColor">@color/primary_text</item>
     </style>
 
-
-    <!-- TEXT STYLES (Roboto) -->
-    <!-- Headline (Roboto Regular, 24sp) -->
-    <style name="headlineText" parent="Base.TextAppearance.AppCompat.Headline">
-        <item name="android:textColor">@color/subheaderText</item>
+    <!-- Medium 14sp, slightly bolder (Roboto Medium) -->
+    <style name="textMediumBold" parent="Base.TextAppearance.AppCompat.Body2">
+        <item name="android:textColor">@color/secondary_text</item>
     </style>
 
-    <!-- Title (Roboto Medium, 20sp) -->
-    <style name="titleText" parent="Base.TextAppearance.AppCompat.Title">
-        <item name="android:textColor">@color/subheaderText</item>
+    <!-- Medium 14sp (Roboto Regular) -->
+    <style name="textMedium" parent="Base.TextAppearance.AppCompat.Body1">
+        <item name="android:textColor">@color/secondary_text</item>
     </style>
 
-    <!-- Subheader (Roboto Regular, 16sp) -->
-    <style name="subheaderText" parent="Base.TextAppearance.AppCompat.Subhead">
-        <item name="android:textColor">@color/subheaderText</item>
-    </style>
-
-    <!-- Body 2 (Roboto Medium, 14sp) -->
-    <style name="body2Text" parent="Base.TextAppearance.AppCompat.Body2">
-        <item name="android:textColor">@color/subheaderText</item>
-    </style>
-
-    <!-- Body 1 (Roboto Regular, 14sp) -->
-    <style name="body1Text" parent="Base.TextAppearance.AppCompat.Body1">
-        <item name="android:textColor">@color/subheaderText</item>
-    </style>
-
-    <!-- Caption (12sp) -->
-    <style name="captionText" parent="Base.TextAppearance.AppCompat.Caption">
-        <item name="android:textColor">@color/captionText</item>
+    <!-- Small (12sp) -->
+    <style name="textSmall" parent="Base.TextAppearance.AppCompat.Caption">
+        <item name="android:textColor">@color/secondary_text</item>
     </style>
 
     <!-- UI ELEMENTS -->
@@ -133,7 +114,7 @@
 
     <style name="tabTextAppearance" parent="TextAppearance.Design.Tab">
         <item name="android:textSize">14sp</item>
-        <item name="android:textColor">?android:textColorSecondary</item>
+        <item name="android:textColor">@color/secondary_text</item>
         <item name="textAllCaps">false</item>
     </style>
     <!-- end view pager styling -->
@@ -176,7 +157,6 @@
 
     <style name="textViewWithDrawable">
         <item name="android:drawablePadding">@dimen/textDrawablePadding</item>
-        <item name="android:textAppearance">@style/subheaderText</item>
         <item name="android:gravity">center_vertical</item>
     </style>
 


### PR DESCRIPTION
* tap story place to reveal right menu (so it's more easily discoverable)
* fixed the calendar fragments layouts (calendar was taking up the whole screen on my device, pushing the buttons off screen).
* added primary/accent colors etc just to see it reflected in styles. Feel free to change the colors. I picked orange to match the splash screen.
* fixed up button to delete trip from create story activity
* reverted text styles for trip item (@aditikakade, FYI: drawableTint only works for API 23+ so the drawable color for API 22- will just be whatever it is in the xml)