### PR TITLE
basic activity transitions

### DIFF
--- a/app/src/main/java/com/codepath/travel/activities/BaseActivity.java
+++ b/app/src/main/java/com/codepath/travel/activities/BaseActivity.java
@@ -2,6 +2,9 @@ package com.codepath.travel.activities;
 
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.transition.Fade;
+import android.transition.Slide;
+import android.transition.TransitionInflater;
 import android.view.MenuItem;
 import android.widget.Toast;
 
@@ -40,18 +43,42 @@ public abstract class BaseActivity extends AppCompatActivity {
         fragment.show(getSupportFragmentManager(), "errorMessageDialogFragment");
     }
 
+    @Override
+    public boolean onSupportNavigateUp() {
+        onBackPressed();
+        return true;
+    }
+
     /**
      * react to the user tapping the up icon in the action bar
      */
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
-            case android.R.id.home:
-                finish(); // up has slightly different behaviour than back button
-                return true;
             default:
                 return super.onOptionsItemSelected(item);
         }
+    }
+
+    /* Activity Transitions */
+    protected void setupWindowAnimationsEnterRight() {
+        // IF MAKING CHANGES HERE, PLEASE UPDATE StoryActivity!!!
+        Fade fadeOut = (Fade) TransitionInflater.from(this).inflateTransition(R.transition.activity_fade_out);
+        Slide slideRight = (Slide) TransitionInflater.from(this).inflateTransition(R.transition.activity_slide_right);
+        getWindow().setEnterTransition(slideRight); // enter: slide in from right side when being opened
+        getWindow().setExitTransition(fadeOut); // exit: fadeOut when opening another activity
+        // re-enter: should automatically reverse (fadeIn) when returning from another activity
+        // return: should automatically reverse (slideLeft) when closing
+        getWindow().setAllowEnterTransitionOverlap(false); // wait for calling activity's exit transition to be done
+        getWindow().setAllowReturnTransitionOverlap(false); // wait for called activity's return transition to be done?
+    }
+
+    // for detail views: place detail, collage
+    protected void setupWindowAnimationsEnterBottom() {
+        Slide slideUp = (Slide) TransitionInflater.from(this).inflateTransition(R.transition.activity_slide_up);
+        getWindow().setEnterTransition(slideUp); // slide up from bottom when being opened
+        // return: should automatically reverse (slide down) when closing
+        getWindow().setAllowEnterTransitionOverlap(false); // wait for calling activity's exit transition to be done
     }
 
 }

--- a/app/src/main/java/com/codepath/travel/activities/CreateStoryActivity.java
+++ b/app/src/main/java/com/codepath/travel/activities/CreateStoryActivity.java
@@ -89,6 +89,7 @@ public class CreateStoryActivity extends BaseActivity implements OnStartDragList
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_create_story);
+        setupWindowAnimationsEnterRight();
         initializeCommonViews();
         toolbar.setTitle(toolbarTitle);
 
@@ -196,9 +197,8 @@ public class CreateStoryActivity extends BaseActivity implements OnStartDragList
             if (!mStoryPlaces.isEmpty()) {
                 StoryPlace.saveAllInBackground(mStoryPlaces, (ParseException e) -> {
                     if (e == null) {
-                        Toast.makeText(CreateStoryActivity.this, "Trip saved", Toast.LENGTH_LONG).show();
                         setResult(RESULT_OK);
-                        finish();
+                        finishAfterTransition();
                     } else {
                         Log.d(TAG, String.format("Failed: %s", e.getMessage()));
                     }
@@ -313,9 +313,6 @@ public class CreateStoryActivity extends BaseActivity implements OnStartDragList
         // as you specify a parent activity in AndroidManifest.xml.
         //int id = item.getItemId();
         switch (item.getItemId()) {
-            case android.R.id.home:
-                onBackPressed();
-                return true;
             default:
                 return super.onOptionsItemSelected(item);
         }

--- a/app/src/main/java/com/codepath/travel/activities/FollowActivity.java
+++ b/app/src/main/java/com/codepath/travel/activities/FollowActivity.java
@@ -35,6 +35,7 @@ public class FollowActivity extends BaseActivity {
   public void onCreate(Bundle savedInstance) {
     super.onCreate(savedInstance);
     setContentView(R.layout.activity_follow);
+    setupWindowAnimationsEnterRight();
     initializeCommonViews();
     tvNoUsersFound.setVisibility(View.GONE);
     FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();

--- a/app/src/main/java/com/codepath/travel/activities/PlaceDetailActivity.java
+++ b/app/src/main/java/com/codepath/travel/activities/PlaceDetailActivity.java
@@ -112,6 +112,7 @@ public class PlaceDetailActivity extends BaseActivity implements OnMapReadyCallb
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_place_detail);
+        setupWindowAnimationsEnterBottom();
         initializeCommonViews();
 
         String placeId = getIntent().getStringExtra(PLACE_ID_ARG);

--- a/app/src/main/java/com/codepath/travel/activities/PlaceSuggestionActivity.java
+++ b/app/src/main/java/com/codepath/travel/activities/PlaceSuggestionActivity.java
@@ -3,6 +3,7 @@ package com.codepath.travel.activities;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.design.widget.TabLayout;
+import android.support.v4.app.ActivityOptionsCompat;
 import android.support.v4.view.ViewPager;
 import android.view.MenuItem;
 import android.view.View;
@@ -56,6 +57,7 @@ public class PlaceSuggestionActivity extends BaseActivity implements PlacesCartL
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_place_suggestion);
+        setupWindowAnimationsEnterRight();
         initializeCommonViews();
 
         mDestination = getIntent().getStringExtra(DESTINATION_NAME_ARG);
@@ -93,16 +95,17 @@ public class PlaceSuggestionActivity extends BaseActivity implements PlacesCartL
         mStoryPlaces.remove(suggestionPlace);
         setCreateState();
     }
-//
+
     /* Navigation */
     private void launchCreateStoryActivity() {
         Intent createTrip = new Intent(this, CreateStoryActivity.class);
         createTrip.putExtra(Constants.PLACE_NAME_ARG, mDestination);
         createTrip.putExtra(Constants.PLACE_PHOTO_REF_ARG, getIntent().getStringExtra(DESTINATION_PHOTO_ARG));
         createTrip.putExtra(Constants.SUGGESTION_PLACES_LIST_ARG, Parcels.wrap(mStoryPlaces));
-        startActivity(createTrip);
+        ActivityOptionsCompat options = ActivityOptionsCompat.makeSceneTransitionAnimation(PlaceSuggestionActivity.this);
+        startActivity(createTrip, options.toBundle());
         setResult(RESULT_OK);
-        finish();
+        finishAfterTransition();
     }
 
     @Override
@@ -129,7 +132,7 @@ public class PlaceSuggestionActivity extends BaseActivity implements PlacesCartL
     @Override
     public void onBackPressed() {
         setResult(RESULT_OK);
-        finish();
+        finishAfterTransition();
     }
 
     private void setCreateState() {

--- a/app/src/main/java/com/codepath/travel/activities/ProfileViewActivity.java
+++ b/app/src/main/java/com/codepath/travel/activities/ProfileViewActivity.java
@@ -5,8 +5,11 @@ import android.graphics.Color;
 import android.os.Bundle;
 import android.support.design.widget.CollapsingToolbarLayout;
 import android.support.design.widget.TabLayout;
+import android.support.v4.app.ActivityOptionsCompat;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.view.ViewPager;
+import android.transition.Slide;
+import android.view.Gravity;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -57,6 +60,7 @@ public class ProfileViewActivity
     public void onCreate(Bundle savedInstance) {
         super.onCreate(savedInstance);
         setContentView(R.layout.activity_user_profile);
+        setupWindowAnimationsEnterRight();
         initializeCommonViews();
         String userID = getIntent().getStringExtra(USER_ID);
 
@@ -126,7 +130,8 @@ public class ProfileViewActivity
         openStory.putExtra(Constants.TRIP_TITLE_ARG, tripTitle);
         openStory.putExtra(Constants.TRIP_ID_ARG, tripId);
         openStory.putExtra(Constants.IS_OWNER_ARG, isOwner);
-        startActivity(openStory);
+        ActivityOptionsCompat options = ActivityOptionsCompat.makeSceneTransitionAnimation(ProfileViewActivity.this);
+        startActivity(openStory, options.toBundle());
     }
 
     @Override
@@ -163,19 +168,19 @@ public class ProfileViewActivity
 
         initFollowers(user);
         initFollowing(user);
-
+        ActivityOptionsCompat options = ActivityOptionsCompat.makeSceneTransitionAnimation(ProfileViewActivity.this);
         tvFollowersCount.setOnClickListener((View v) -> {
             Intent showFollowers = new Intent(ProfileViewActivity.this, FollowActivity.class);
             showFollowers.putExtra(FollowActivity.SHOW_FOLLOWERS, true);
             showFollowers.putExtra(FollowActivity.USER_ID, user.getObjectId());
-            startActivity(showFollowers);
+            startActivity(showFollowers, options.toBundle());
         });
 
         tvFollowingCount.setOnClickListener((View v) -> {
             Intent showFollowers = new Intent(ProfileViewActivity.this, FollowActivity.class);
             showFollowers.putExtra(FollowActivity.SHOW_FOLLOWERS, false);
             showFollowers.putExtra(FollowActivity.USER_ID, user.getObjectId());
-            startActivity(showFollowers);
+            startActivity(showFollowers, options.toBundle());
         });
 
         // user can't follow himself

--- a/app/src/main/java/com/codepath/travel/activities/SearchActivity.java
+++ b/app/src/main/java/com/codepath/travel/activities/SearchActivity.java
@@ -35,6 +35,7 @@ public class SearchActivity extends BaseActivity {
   public void onCreate(Bundle savedInstance) {
     super.onCreate(savedInstance);
     setContentView(R.layout.activity_search_users);
+    setupWindowAnimationsEnterRight();
     initializeCommonViews();
     setActionBarTitle(toolbarTitle);
     tvNoUsersFound.setVisibility(View.GONE);

--- a/app/src/main/java/com/codepath/travel/activities/StoryCollageActivity.java
+++ b/app/src/main/java/com/codepath/travel/activities/StoryCollageActivity.java
@@ -3,7 +3,6 @@ package com.codepath.travel.activities;
 import static com.codepath.travel.Constants.TRIP_ID_ARG;
 import static com.codepath.travel.Constants.TRIP_TITLE_ARG;
 
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.StaggeredGridLayoutManager;
@@ -26,16 +25,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import butterknife.BindString;
 import butterknife.BindView;
-import butterknife.ButterKnife;
 
-public class StoryCollageActivity extends AppCompatActivity {
+public class StoryCollageActivity extends BaseActivity {
     private static final int GRID_NUM_COLUMNS = 2;
     private static final int GRID_SPACE_SIZE = 5;
-
-    // strings
-    @BindString(R.string.toolbar_title_story_collage) String toolbarTitle;
 
     // views
     @BindView(R.id.toolbar) Toolbar toolbar;
@@ -49,11 +43,9 @@ public class StoryCollageActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_story_collage);
-        ButterKnife.bind(this);
-
-        toolbar.setTitle(String.format(toolbarTitle, getIntent().getStringExtra(TRIP_TITLE_ARG)));
-        setSupportActionBar(toolbar);
-        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        setupWindowAnimationsEnterBottom();
+        initializeCommonViews();
+        setActionBarTitle(getIntent().getStringExtra(TRIP_TITLE_ARG));
 
         mTripID = getIntent().getStringExtra(TRIP_ID_ARG);
 
@@ -111,14 +103,6 @@ public class StoryCollageActivity extends AppCompatActivity {
         // automatically handle clicks on the Home/Up button, so long
         // as you specify a parent activity in AndroidManifest.xml.
         int id = item.getItemId();
-
-        if (id == android.R.id.home) {
-            finish();
-            return true;
-        } else if (id == R.id.miShare) {
-            // Todo: share dialog fragment? followers/following must be implemented first
-            Toast.makeText(this, "Todo: share dialog fragment", Toast.LENGTH_SHORT).show();
-        }
 
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/java/com/codepath/travel/activities/StoryMapViewActivity.java
+++ b/app/src/main/java/com/codepath/travel/activities/StoryMapViewActivity.java
@@ -59,6 +59,7 @@ public class StoryMapViewActivity extends BaseActivity {
   public void onCreate(Bundle savedInstance) {
     super.onCreate(savedInstance);
     setContentView(R.layout.activity_story_map);
+    setupWindowAnimationsEnterRight();
     initializeCommonViews();
     MapsInitializer.initialize(getApplicationContext());
     defaultMarker = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_RED);

--- a/app/src/main/java/com/codepath/travel/adapters/UsersAdapter.java
+++ b/app/src/main/java/com/codepath/travel/adapters/UsersAdapter.java
@@ -1,7 +1,9 @@
 package com.codepath.travel.adapters;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.support.v4.app.ActivityOptionsCompat;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -10,6 +12,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.codepath.travel.R;
+import com.codepath.travel.activities.HomeActivity;
 import com.codepath.travel.activities.ProfileViewActivity;
 import com.codepath.travel.helper.ImageUtils;
 import com.codepath.travel.models.parse.User;
@@ -61,7 +64,9 @@ public class UsersAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         ivProfilePhoto.setOnClickListener((View v) -> {
             Intent viewProfile = new Intent(mContext, ProfileViewActivity.class);
             viewProfile.putExtra(ProfileViewActivity.USER_ID, user.getObjectId());
-            mContext.startActivity(viewProfile);
+            ActivityOptionsCompat
+                    options = ActivityOptionsCompat.makeSceneTransitionAnimation((Activity) mContext);
+            mContext.startActivity(viewProfile, options.toBundle());
         });
 
         TextView tvUsername = viewHolder.getTvUsername();

--- a/app/src/main/java/com/codepath/travel/fragments/PlacesListFragment.java
+++ b/app/src/main/java/com/codepath/travel/fragments/PlacesListFragment.java
@@ -4,6 +4,7 @@ import static com.codepath.travel.activities.PlaceDetailActivity.LAT_LNG_ARG;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v4.app.ActivityOptionsCompat;
 import android.support.v4.app.Fragment;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -16,6 +17,8 @@ import android.widget.ProgressBar;
 import com.codepath.travel.Constants;
 import com.codepath.travel.R;
 import com.codepath.travel.activities.PlaceDetailActivity;
+import com.codepath.travel.activities.PlaceSuggestionActivity;
+import com.codepath.travel.activities.StoryActivity;
 import com.codepath.travel.adapters.PlaceSuggestionArrayAdapter;
 import com.codepath.travel.helper.ItemClickSupport;
 import com.codepath.travel.models.SuggestionPlace;
@@ -126,6 +129,8 @@ public class PlacesListFragment extends Fragment {
     placeDetail.putExtra(PlaceDetailActivity.POSITION_ARG, position);
     placeDetail.putExtra(PLACE_ADDED_ARG, suggestionPlace.isSelected());
     placeDetail.putExtra(LAT_LNG_ARG, new LatLng(suggestionPlace.getLatitude(), suggestionPlace.getLongitude()));
-    startActivityForResult(placeDetail, Constants.PLACE_DETAIL_REQUEST);
+
+    ActivityOptionsCompat options = android.support.v4.app.ActivityOptionsCompat.makeSceneTransitionAnimation(getActivity());
+    startActivityForResult(placeDetail, Constants.PLACE_DETAIL_REQUEST, options.toBundle());
   }
 }

--- a/app/src/main/res/menu/menu_collage.xml
+++ b/app/src/main/res/menu/menu_collage.xml
@@ -3,10 +3,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:context=".activities.PlaceSuggestionActivity">
 
-    <item
-        android:id="@+id/miShare"
-        android:orderInCategory="10"
-        android:title="@string/share_story"
-        android:icon="@android:drawable/ic_menu_share"
-        app:showAsAction="ifRoom" />
+    <!--<item-->
+        <!--android:id="@+id/miShare"-->
+        <!--android:orderInCategory="10"-->
+        <!--android:title="@string/share_story"-->
+        <!--android:icon="@android:drawable/ic_menu_share"-->
+        <!--app:showAsAction="ifRoom" />-->
 </menu>

--- a/app/src/main/res/transition/activity_fade_in.xml
+++ b/app/src/main/res/transition/activity_fade_in.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<fade xmlns:android="http://schemas.android.com/apk/res/"
+    android:fadingMode="fade_in"
+    android:duration="@integer/transition_duration"/>

--- a/app/src/main/res/transition/activity_fade_out.xml
+++ b/app/src/main/res/transition/activity_fade_out.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<fade xmlns:android="http://schemas.android.com/apk/res/"
+    android:fadingMode="fade_out"
+    android:duration="@integer/transition_duration"/>

--- a/app/src/main/res/transition/activity_slide_down.xml
+++ b/app/src/main/res/transition/activity_slide_down.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<slide xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="@integer/transition_duration"
+    android:slideEdge="top" />

--- a/app/src/main/res/transition/activity_slide_left.xml
+++ b/app/src/main/res/transition/activity_slide_left.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<slide xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="@integer/transition_duration"
+    android:slideEdge="left" />

--- a/app/src/main/res/transition/activity_slide_right.xml
+++ b/app/src/main/res/transition/activity_slide_right.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<slide xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="@integer/transition_duration"
+    android:slideEdge="right" />

--- a/app/src/main/res/transition/activity_slide_up.xml
+++ b/app/src/main/res/transition/activity_slide_up.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<slide xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="@integer/transition_duration"
+    android:slideEdge="bottom" />

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="transition_duration">1000</integer>
+</resources>


### PR DESCRIPTION
#72 

Added basic activity to activity transitions. I used the newer Transitions Framework because I thought it would be fun to play with the shared element transitions later on.

Resources:
* http://guides.codepath.com/android/Animations#activity-transitions-in-lollipop
* https://github.com/lgvalle/Material-Animations

General scenarios:
* when launching a new activity, current activity fades out, then new activity slides in from right
* when closing this new activity, the transitions are reversed (new activity slides out to right, old activity fades in)
* detail views (place detail, collage) slide up from the bottom instead.

Issues:
* Sometimes the recycler views don't animate in nicely (story view and collage view)
* I did not look at adding transitions for Splash or Login (ParseAndroidLogin).