### PR TITLE
hook up place detail view to create trip and ohter people's story places

### DIFF
--- a/app/src/main/java/com/codepath/travel/activities/MediaCollageActivity.java
+++ b/app/src/main/java/com/codepath/travel/activities/MediaCollageActivity.java
@@ -84,6 +84,7 @@ public class MediaCollageActivity extends BaseActivity implements
     @BindView(R.id.tvCheckinDate) TextView tvCheckinDate;
     @BindView(R.id.rbUserRating) RatingBar rbUserRating;
     @BindView(R.id.rvMediaItems) RecyclerView rvMediaItems;
+    @BindView(R.id.tvNoMedia) TextView tvNoMedia;
 
     // variables
     private String mStoryPlaceId;
@@ -120,8 +121,12 @@ public class MediaCollageActivity extends BaseActivity implements
                 mStoryPlace = storyPlace;
                 Media.getMediaForStoryPlace(mStoryPlace, (mediaItems, e1) -> {
                     if (e1 == null) {
-                        mMediaItems.addAll(mediaItems);
-                        mCollageAdapter.notifyDataSetChanged();
+                        if (mediaItems.size() > 0) {
+                            tvNoMedia.setVisibility(View.GONE);
+                            mMediaItems.addAll(mediaItems);
+                            rvMediaItems.setVisibility(View.VISIBLE);
+                            mCollageAdapter.notifyDataSetChanged();
+                        }
                     } else {
                         Log.d(TAG, String.format("media fetch failed for storyplace %d: %s",
                                 mStoryPlaceId,  e1.toString()));
@@ -259,6 +264,8 @@ public class MediaCollageActivity extends BaseActivity implements
                 if (position < 0) {
                     mMediaItems.add(mediaItem);
                 }
+                tvNoMedia.setVisibility(View.GONE);
+                rvMediaItems.setVisibility(View.VISIBLE);
                 mCollageAdapter.notifyDataSetChanged();
             } else {
                 Log.d(TAG, String.format("Save media error for id %s: %s",
@@ -274,6 +281,10 @@ public class MediaCollageActivity extends BaseActivity implements
             if (e == null) {
                 mMediaItems.remove(mediaItem);
                 mCollageAdapter.notifyDataSetChanged();
+                if (mMediaItems.size() == 0) {
+                    tvNoMedia.setVisibility(View.VISIBLE);
+                    rvMediaItems.setVisibility(View.GONE);
+                }
             } else {
                 Log.d(TAG, String.format("Delete media error for id %s: %s",
                         mediaItem.getObjectId(), e.toString()));
@@ -411,6 +422,8 @@ public class MediaCollageActivity extends BaseActivity implements
                     Log.d("error", me.toString());
                 } else {
                     mMediaItems.add(media);
+                    tvNoMedia.setVisibility(View.GONE);
+                    rvMediaItems.setVisibility(View.VISIBLE);
                     mCollageAdapter.notifyDataSetChanged();
                 }
             });

--- a/app/src/main/java/com/codepath/travel/activities/PlaceDetailActivity.java
+++ b/app/src/main/java/com/codepath/travel/activities/PlaceDetailActivity.java
@@ -182,7 +182,7 @@ public class PlaceDetailActivity extends BaseActivity implements OnMapReadyCallb
                 .position(mLatLng)
                 .title(placeName)
                 .icon(BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_ORANGE)));
-        mMap.moveCamera(CameraUpdateFactory.newLatLngZoom(mLatLng, 7f));
+        mMap.moveCamera(CameraUpdateFactory.newLatLngZoom(mLatLng, 16f));
     }
 
     private void setupViews(JSONObject data) throws JSONException {
@@ -335,7 +335,6 @@ public class PlaceDetailActivity extends BaseActivity implements OnMapReadyCallb
     }
 
     private void onGoogleUrlClick(String googleUrl) {
-        Toast.makeText(PlaceDetailActivity.this, "GoogleURL: " + googleUrl, Toast.LENGTH_SHORT).show();
         launchMapsIntent(googleUrl);
     }
 

--- a/app/src/main/java/com/codepath/travel/adapters/StoryPlaceArrayAdapter.java
+++ b/app/src/main/java/com/codepath/travel/adapters/StoryPlaceArrayAdapter.java
@@ -15,13 +15,13 @@ import com.codepath.travel.helper.ItemTouchHelperViewHolder;
 import com.codepath.travel.models.parse.StoryPlace;
 import com.codepath.travel.net.GoogleAsyncHttpClient;
 
+import java.util.Date;
 import java.util.List;
 
 /**
  * Adapter for story places being added to a new trip.
  */
 public class StoryPlaceArrayAdapter extends RecyclerView.Adapter<StoryPlaceArrayAdapter.StoryPlaceViewHolder> {
-
 
     private List<StoryPlace> mStoryPlaces;
     public Context mContext;
@@ -85,12 +85,10 @@ public class StoryPlaceArrayAdapter extends RecyclerView.Adapter<StoryPlaceArray
         }
 
         public void populate(StoryPlace storyPlace) {
-            ivPlacePhoto.setImageResource(0);
             ImageUtils.loadImage(
                 ivPlacePhoto,
                 GoogleAsyncHttpClient.getPlacePhotoUrl(storyPlace.getPhotoUrl()));
             tvPlaceName.setText(storyPlace.getName());
-
         }
 
         @Override

--- a/app/src/main/java/com/codepath/travel/adapters/SwipeStoryPlaceAdapter.java
+++ b/app/src/main/java/com/codepath/travel/adapters/SwipeStoryPlaceAdapter.java
@@ -3,6 +3,8 @@ package com.codepath.travel.adapters;
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
 
+import static com.codepath.travel.R.id.ivCollageIcon;
+import static com.codepath.travel.R.id.ivPlacePhoto;
 import static com.codepath.travel.R.id.swipe;
 import static com.codepath.travel.helper.DateUtils.FUTURE;
 import static com.codepath.travel.helper.DateUtils.PAST;
@@ -119,6 +121,7 @@ public class SwipeStoryPlaceAdapter extends RecyclerSwipeAdapter<SwipeStoryPlace
         @BindView(R.id.cbCheckin) AppCompatCheckBox cbCheckin;
         @BindView(R.id.tvCheckin) TextView tvCheckin;
         @BindView(R.id.rbUserRating) RatingBar rbUserRating;
+        @BindView(R.id.ivCollageIcon) ImageView ivCollageIcon;
 
         // swipe views
         @BindView(swipe) SwipeLayout swipeLayout;
@@ -145,7 +148,7 @@ public class SwipeStoryPlaceAdapter extends RecyclerSwipeAdapter<SwipeStoryPlace
                 swipeLayout.setSwipeEnabled(true);
                 swipeLayout.setShowMode(SwipeLayout.ShowMode.LayDown);
                 swipeLayout.setClickToClose(true);
-                setupListeners();
+                setupSwipeMenuListeners();
             } else {
                 swipeLayout.setSwipeEnabled(false);
             }
@@ -155,16 +158,26 @@ public class SwipeStoryPlaceAdapter extends RecyclerSwipeAdapter<SwipeStoryPlace
             mStoryPlace = storyPlace;
 
             // photo and name
-            ivPlacePhoto.setImageResource(0);
             ImageUtils.loadImage(ivPlacePhoto,
                     GoogleAsyncHttpClient.getPlacePhotoUrl(storyPlace.getPhotoUrl()));
+            ivPlacePhoto.setOnClickListener(
+                    v -> listener.onStoryPlaceInfo(getRealPosition(storyPlace)));
             tvPlaceName.setText(storyPlace.getName());
+
+            if (isOwner && datesRelation != FUTURE) {
+                ivCollageIcon.setVisibility(GONE);
+            } else {
+                // show collage icon for people to tap on
+                ivCollageIcon.setVisibility(VISIBLE);
+                ivCollageIcon.setOnClickListener(
+                        v -> listener.mediaOnClick(getRealPosition(mStoryPlace)));
+            }
 
             // check-in and user rating
             setupCheckinCheckbox(storyPlace);
         }
 
-        private void setupListeners() {
+        private void setupSwipeMenuListeners() {
             // left menu
             ivDelete.setOnClickListener(v -> onItemDelete(getRealPosition(mStoryPlace)));
 

--- a/app/src/main/res/layout/activity_place_detail.xml
+++ b/app/src/main/res/layout/activity_place_detail.xml
@@ -143,7 +143,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/detail_map_height"
                 android:layout_below="@id/llActions"
-                map:cameraZoom="7"
+                map:cameraZoom="16"
                 map:mapType="normal"
                 map:liteMode="true"/>
 

--- a/app/src/main/res/layout/activity_story_collage.xml
+++ b/app/src/main/res/layout/activity_story_collage.xml
@@ -99,6 +99,18 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:scrollbars="vertical"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        android:visibility="gone"/>
+
+    <TextView
+        android:id="@+id/tvNoMedia"
+        android:text="@string/no_media"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/activity_horizontal_margin"
+        android:textAppearance="@style/textMedium"
+        android:textColor="@color/tertiary_text"
+        android:textAlignment="center"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
 
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/item_storyplace.xml
+++ b/app/src/main/res/layout/item_storyplace.xml
@@ -60,7 +60,7 @@
 
             <ImageView
                 android:id="@+id/ivMedia"
-                app:srcCompat="@drawable/ic_create"
+                app:srcCompat="@drawable/ic_photo_library"
                 android:layout_width="@dimen/icon_tap_size"
                 android:layout_height="@dimen/icon_tap_size"
                 android:scaleType="center"/>
@@ -127,8 +127,19 @@
                 android:layout_toEndOf="@id/ivPlacePhoto"
                 android:layout_toStartOf="@id/tvCheckin"
                 android:layout_marginStart="@dimen/activity_horizontal_margin"
+                android:paddingRight="@dimen/margin_s"
                 tools:text="Place Name Name Name Name Name Very Long Name"
                 android:textAppearance="@style/textMediumBold"/>
+
+            <ImageView
+                android:id="@+id/ivCollageIcon"
+                app:srcCompat="@drawable/ic_photo_library"
+                android:layout_width="@dimen/icon_size"
+                android:layout_height="@dimen/icon_size"
+                android:layout_alignParentBottom="true"
+                android:layout_alignParentEnd="true"
+                android:tint="@color/icon_gray"
+                android:visibility="gone"/>
         </RelativeLayout>
     </android.support.v7.widget.CardView>
 </com.daimajia.swipe.SwipeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,5 +110,6 @@
         <item>@string/set_user_cover</item>
         <item>@string/set_user_profile</item>
     </string-array>
+    <string name="no_media">Nothing to look at here :/</string>
 
 </resources>


### PR DESCRIPTION
Issue: #115 

Added tap to show place detail for:
* Create Story story place items (click anywhere, the whole recycler view responds)
* Story Activity 
   * tap on image
   * when viewing another user's story, you can tap on a photo library icon in the bottom right to bring up the collage view (consistent with map view)

Other minor fixes:
* up button on create story activity was glitching on exit transitions
* fixed map zoom level on place detail
* placeholder text for empty collages (this bit was very poorly written, and should get cleaned up in the future, sincerest apologies)


